### PR TITLE
Use org.reactivestreams Publisher type in API

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -68,11 +68,11 @@ ReactivePulsarClient reactivePulsarClient = AdaptedReactivePulsarClientFactory.c
 
 [source,java]
 ----
-ReactiveMessageSender<String> messageSender = reactivePulsarClient
+ReactorMessageSender<String> messageSender = reactivePulsarClient
         .messageSender(Schema.STRING)
         .topic(topicName)
         .maxInflight(100)
-        .build();
+        .buildReactor();
 Mono<MessageId> messageId = messageSender
         .send(MessageSpec.of("Hello world!"));
 // for demonstration
@@ -115,12 +115,12 @@ Usage example of cache
 
 [source,java]
 ----
-ReactiveMessageSender<String> messageSender = reactivePulsarClient
+ReactorMessageSender<String> messageSender = reactivePulsarClient
         .messageSender(Schema.STRING)
         .cache(AdaptedReactivePulsarClientFactory.createCache())
         .topic(topicName)
         .maxInflight(100)
-        .build();
+        .buildReactor();
 Mono<MessageId> messageId = messageSender
         .send(MessageSpec.of("Hello world!"));
 // for demonstration

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ junit-jupiter = "5.8.2"
 log4j = "2.18.0"
 slf4j = "1.7.36"
 reactor = "3.4.22"
+rxjava = "3.1.5"
 assertj = "3.23.1"
 testcontainers = "1.17.3"
 jctools = "3.3.0"
@@ -18,6 +19,7 @@ pulsar-client-shaded = { module = "org.apache.pulsar:pulsar-client", version.ref
 pulsar-client-api = { module = "org.apache.pulsar:pulsar-client-api", version.ref = "pulsar" }
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactor" }
 reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "reactor" }
+rxjava = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessagePipelineE2ETest.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessagePipelineE2ETest.java
@@ -39,8 +39,8 @@ import org.apache.pulsar.reactive.client.api.MessageSpec;
 import org.apache.pulsar.reactive.client.api.MessageSpecBuilder;
 import org.apache.pulsar.reactive.client.api.ReactiveMessagePipeline;
 import org.apache.pulsar.reactive.client.api.ReactiveMessagePipelineBuilder;
-import org.apache.pulsar.reactive.client.api.ReactiveMessageSender;
 import org.apache.pulsar.reactive.client.api.ReactivePulsarClient;
+import org.apache.pulsar.reactive.client.api.ReactorMessageSender;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -66,8 +66,8 @@ public class ReactiveMessagePipelineE2ETest {
 
 			ReactivePulsarClient reactivePulsarClient = AdaptedReactivePulsarClientFactory.create(pulsarClient);
 
-			ReactiveMessageSender<String> messageSender = reactivePulsarClient.messageSender(Schema.STRING)
-					.topic(topicName).build();
+			ReactorMessageSender<String> messageSender = reactivePulsarClient.messageSender(Schema.STRING)
+					.topic(topicName).buildReactor();
 			messageSender.send(Flux.range(1, 100).map(Object::toString).map(MessageSpec::of)).blockLast();
 
 			List<String> messages = Collections.synchronizedList(new ArrayList<>());
@@ -96,8 +96,8 @@ public class ReactiveMessagePipelineE2ETest {
 
 			ReactivePulsarClient reactivePulsarClient = AdaptedReactivePulsarClientFactory.create(pulsarClient);
 
-			ReactiveMessageSender<Integer> messageSender = reactivePulsarClient.messageSender(Schema.INT32)
-					.topic(topicName).build();
+			ReactorMessageSender<Integer> messageSender = reactivePulsarClient.messageSender(Schema.INT32)
+					.topic(topicName).buildReactor();
 
 			List<MessageSpec<Integer>> messageSpecs = generateRandomOrderedMessagesWhereSingleKeyIsOrdered(
 					messageOrderScenario);

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessageReaderE2ETest.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessageReaderE2ETest.java
@@ -23,10 +23,10 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.reactive.client.api.MessageSpec;
-import org.apache.pulsar.reactive.client.api.ReactiveMessageReader;
-import org.apache.pulsar.reactive.client.api.ReactiveMessageSender;
 import org.apache.pulsar.reactive.client.api.ReactiveMessageSenderCache;
 import org.apache.pulsar.reactive.client.api.ReactivePulsarClient;
+import org.apache.pulsar.reactive.client.api.ReactorMessageReader;
+import org.apache.pulsar.reactive.client.api.ReactorMessageSender;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
@@ -44,13 +44,13 @@ public class ReactiveMessageReaderE2ETest {
 
 			ReactivePulsarClient reactivePulsarClient = AdaptedReactivePulsarClientFactory.create(pulsarClient);
 
-			ReactiveMessageSender<String> messageSender = reactivePulsarClient.messageSender(Schema.STRING)
-					.cache(producerCache).topic(topicName).build();
+			ReactorMessageSender<String> messageSender = reactivePulsarClient.messageSender(Schema.STRING)
+					.cache(producerCache).topic(topicName).buildReactor();
 			messageSender.send(Flux.range(1, 100).map(Object::toString).map(MessageSpec::of)).blockLast();
 
-			ReactiveMessageReader<String> messageReader = reactivePulsarClient.messageReader(Schema.STRING)
-					.topic(topicName).build();
-			List<String> messages = messageReader.readMessages().map(Message::getValue).collectList().block();
+			ReactorMessageReader<String> messageReader = reactivePulsarClient.messageReader(Schema.STRING)
+					.topic(topicName).buildReactor();
+			List<String> messages = messageReader.read().map(Message::getValue).collectList().block();
 
 			assertThat(messages).isEqualTo(Flux.range(1, 100).map(Object::toString).collectList().block());
 		}

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessageSenderE2ETest.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessageSenderE2ETest.java
@@ -28,9 +28,9 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.reactive.client.api.MessageSpec;
-import org.apache.pulsar.reactive.client.api.ReactiveMessageSender;
 import org.apache.pulsar.reactive.client.api.ReactiveMessageSenderCache;
 import org.apache.pulsar.reactive.client.api.ReactivePulsarClient;
+import org.apache.pulsar.reactive.client.api.ReactorMessageSender;
 import org.apache.pulsar.reactive.client.internal.adapter.ConcurrentHashMapProducerCacheProvider;
 import org.apache.pulsar.reactive.client.producercache.CaffeineProducerCacheProvider;
 import org.junit.jupiter.api.Test;
@@ -61,8 +61,8 @@ public class ReactiveMessageSenderE2ETest {
 
 			ReactivePulsarClient reactivePulsarClient = AdaptedReactivePulsarClientFactory.create(pulsarClient);
 
-			ReactiveMessageSender<String> messageSender = reactivePulsarClient.messageSender(Schema.STRING)
-					.topic(topicName).maxInflight(1).build();
+			ReactorMessageSender<String> messageSender = reactivePulsarClient.messageSender(Schema.STRING)
+					.topic(topicName).maxInflight(1).build().adapt(ReactorMessageSender.class);
 			MessageId messageId = messageSender.send(MessageSpec.of("Hello world!")).block();
 			assertThat(messageId).isNotNull();
 
@@ -84,8 +84,8 @@ public class ReactiveMessageSenderE2ETest {
 
 			ReactivePulsarClient reactivePulsarClient = AdaptedReactivePulsarClientFactory.create(pulsarClient);
 
-			ReactiveMessageSender<String> messageSender = reactivePulsarClient.messageSender(Schema.STRING)
-					.cache(producerCache).maxInflight(1).topic(topicName).build();
+			ReactorMessageSender<String> messageSender = reactivePulsarClient.messageSender(Schema.STRING)
+					.cache(producerCache).maxInflight(1).topic(topicName).build().adapt(ReactorMessageSender.class);
 			MessageId messageId = messageSender.send(MessageSpec.of("Hello world!")).block();
 			assertThat(messageId).isNotNull();
 

--- a/pulsar-client-reactive-adapter/src/main/java/org/apache/pulsar/reactive/client/internal/adapter/AdaptedReactiveMessageReader.java
+++ b/pulsar-client-reactive-adapter/src/main/java/org/apache/pulsar/reactive/client/internal/adapter/AdaptedReactiveMessageReader.java
@@ -127,13 +127,7 @@ class AdaptedReactiveMessageReader<T> implements ReactiveMessageReader<T> {
 	}
 
 	@Override
-	public Mono<Message<T>> readMessage() {
-		return createReactiveReaderAdapter(this.startAtSpec)
-				.usingReader((reader) -> readNextMessage(reader, this.endOfStreamAction));
-	}
-
-	@Override
-	public Flux<Message<T>> readMessages() {
+	public Flux<Message<T>> read() {
 		return createReactiveReaderAdapter(this.startAtSpec).usingReaderMany((reader) -> {
 			Mono<Message<T>> messageMono = readNextMessage(reader, this.endOfStreamAction);
 			if (this.endOfStreamAction == EndOfStreamAction.COMPLETE) {

--- a/pulsar-client-reactive-adapter/src/main/java/org/apache/pulsar/reactive/client/internal/adapter/AdaptedReactiveMessageSender.java
+++ b/pulsar-client-reactive-adapter/src/main/java/org/apache/pulsar/reactive/client/internal/adapter/AdaptedReactiveMessageSender.java
@@ -178,11 +178,6 @@ class AdaptedReactiveMessageSender<T> implements ReactiveMessageSender<T> {
 		}
 	}
 
-	@Override
-	public Mono<MessageId> send(MessageSpec<T> messageSpec) {
-		return createReactiveProducerAdapter().usingProducer((producer) -> createMessageMono(messageSpec, producer));
-	}
-
 	private Mono<MessageId> createMessageMono(MessageSpec<T> messageSpec, Producer<T> producer) {
 		return PulsarFutureAdapter.adaptPulsarFuture(() -> {
 			TypedMessageBuilder<T> typedMessageBuilder = producer.newMessage();

--- a/pulsar-client-reactive-api/build.gradle
+++ b/pulsar-client-reactive-api/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	api libs.reactor.core
 	api libs.pulsar.client.api
 	api libs.slf4j.api
+	compileOnly libs.rxjava
 	implementation libs.jctools.core
 }
 

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageConsumerBuilder.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageConsumerBuilder.java
@@ -245,4 +245,21 @@ public interface ReactiveMessageConsumerBuilder<T> {
 
 	ReactiveMessageConsumer<T> build();
 
+	/**
+	 * Build a Reactor based message reader.
+	 * @return the reactor based message reader instance
+	 */
+	default ReactorMessageConsumer<T> buildReactor() {
+		return build().toReactor();
+	}
+
+	/**
+	 * Build a RxJava 3 based message reader. Use only if you have RxJava 3 on the class
+	 * path (not pulled by this pulsar-client-reactive-api).
+	 * @return the RxJava 3 based message reader instance
+	 */
+	default RxJavaMessageConsumer<T> buildRxJava() {
+		return build().toRxJava();
+	}
+
 }

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageReaderBuilder.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageReaderBuilder.java
@@ -41,6 +41,23 @@ public interface ReactiveMessageReaderBuilder<T> {
 
 	ReactiveMessageReader<T> build();
 
+	/**
+	 * Build a Reactor based message reader.
+	 * @return the reactor based message reader instance
+	 */
+	default ReactorMessageReader<T> buildReactor() {
+		return build().toReactor();
+	}
+
+	/**
+	 * Build a RxJava 3 based message reader. Use only if you have RxJava 3 on the class
+	 * path (not pulled by this pulsar-client-reactive-api).
+	 * @return the RxJava 3 based message reader instance
+	 */
+	default RxJavaMessageReader<T> buildRxJava() {
+		return build().toRxJava();
+	}
+
 	default ReactiveMessageReaderBuilder<T> topic(String topicName) {
 		getMutableSpec().getTopicNames().add(topicName);
 		return this;

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageSenderBuilder.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageSenderBuilder.java
@@ -185,4 +185,21 @@ public interface ReactiveMessageSenderBuilder<T> {
 
 	ReactiveMessageSender<T> build();
 
+	/**
+	 * Build a Reactor based message sender.
+	 * @return the reactor based message sender instance
+	 */
+	default ReactorMessageSender<T> buildReactor() {
+		return build().toReactor();
+	}
+
+	/**
+	 * Build a RxJava 3 based message sender. Use only if you have RxJava 3 on the class
+	 * path (not pulled by this pulsar-client-reactive-api).
+	 * @return the RxJava 3 based message sender instance
+	 */
+	default RxJavaMessageSender<T> buildRxJava() {
+		return build().toRxJava();
+	}
+
 }

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactorMessageConsumer.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactorMessageConsumer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pulsar.reactive.client.api;
+
+import java.util.function.Function;
+
+import org.apache.pulsar.client.api.Message;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class ReactorMessageConsumer<T> implements ReactiveMessageConsumer<T> {
+
+	private final ReactiveMessageConsumer<T> delegate;
+
+	public ReactorMessageConsumer(ReactiveMessageConsumer<T> delegate) {
+		this.delegate = delegate;
+	}
+
+	public <R> Mono<R> consumeOne(Function<Mono<Message<T>>, Publisher<MessageResult<R>>> messageHandler) {
+		return Mono.from(this.delegate.consume((messages) -> messageHandler.apply(messages.next())));
+	}
+
+	@Override
+	public <R> Flux<R> consume(Function<Flux<Message<T>>, Publisher<MessageResult<R>>> messageHandler) {
+		return Flux.from(this.delegate.consume(messageHandler));
+	}
+
+	@Override
+	public Mono<Void> consumeNothing() {
+		return Mono.from(this.delegate.consumeNothing());
+	}
+
+}

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactorMessageReader.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactorMessageReader.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pulsar.reactive.client.api;
+
+import org.apache.pulsar.client.api.Message;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class ReactorMessageReader<T> implements ReactiveMessageReader<T> {
+
+	private final ReactiveMessageReader<T> delegate;
+
+	public ReactorMessageReader(ReactiveMessageReader<T> delegate) {
+		this.delegate = delegate;
+	}
+
+	public Mono<Message<T>> readOne() {
+		return Mono.from(this.delegate.read());
+	}
+
+	@Override
+	public Flux<Message<T>> read() {
+		return Flux.from(this.delegate.read());
+	}
+
+}

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactorMessageSender.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactorMessageSender.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pulsar.reactive.client.api;
+
+import org.apache.pulsar.client.api.MessageId;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class ReactorMessageSender<T> implements ReactiveMessageSender<T> {
+
+	private final ReactiveMessageSender<T> delegate;
+
+	public ReactorMessageSender(ReactiveMessageSender<T> delegate) {
+		this.delegate = delegate;
+	}
+
+	public Mono<MessageId> send(MessageSpec<T> messageSpec) {
+		return send(Mono.just(messageSpec)).single();
+	}
+
+	@Override
+	public Flux<MessageId> send(Publisher<MessageSpec<T>> messageSpecs) {
+		return Flux.from(this.delegate.send(messageSpecs));
+	}
+
+}

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/RxJavaMessageConsumer.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/RxJavaMessageConsumer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pulsar.reactive.client.api;
+
+import java.util.function.Function;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import org.apache.pulsar.client.api.Message;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+
+public class RxJavaMessageConsumer<T> implements ReactiveMessageConsumer<T> {
+
+	private final ReactiveMessageConsumer<T> delegate;
+
+	public RxJavaMessageConsumer(ReactiveMessageConsumer<T> delegate) {
+		this.delegate = delegate;
+	}
+
+	public <R> Single<R> consumeOne(Function<Single<Message<T>>, Single<MessageResult<R>>> messageHandler) {
+		return Single.fromPublisher(
+				this.delegate.consume((messages) -> messageHandler.apply(Single.fromPublisher(messages)).toFlowable()));
+	}
+
+	@Override
+	public <R> Flowable<R> consume(Function<Flux<Message<T>>, Publisher<MessageResult<R>>> messageHandler) {
+		return Flowable.fromPublisher(this.delegate.consume(messageHandler));
+	}
+
+	@Override
+	public Flowable<Void> consumeNothing() {
+		return Flowable.fromPublisher(this.delegate.consumeNothing());
+	}
+
+}

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/RxJavaMessageReader.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/RxJavaMessageReader.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pulsar.reactive.client.api;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import org.apache.pulsar.client.api.Message;
+
+public class RxJavaMessageReader<T> implements ReactiveMessageReader<T> {
+
+	private final ReactiveMessageReader<T> delegate;
+
+	public RxJavaMessageReader(ReactiveMessageReader<T> delegate) {
+		this.delegate = delegate;
+	}
+
+	public Single<Message<T>> readOne() {
+		return Single.fromPublisher(this.delegate.read());
+	}
+
+	@Override
+	public Flowable<Message<T>> read() {
+		return Flowable.fromPublisher(this.delegate.read());
+	}
+
+}

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/RxJavaMessageSender.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/RxJavaMessageSender.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pulsar.reactive.client.api;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import org.apache.pulsar.client.api.MessageId;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+public class RxJavaMessageSender<T> implements ReactiveMessageSender<T> {
+
+	private final ReactiveMessageSender<T> delegate;
+
+	public RxJavaMessageSender(ReactiveMessageSender<T> delegate) {
+		this.delegate = delegate;
+	}
+
+	public Single<MessageId> send(MessageSpec<T> messageSpec) {
+		return Single.fromPublisher(this.delegate.send(Mono.just(messageSpec)));
+	}
+
+	@Override
+	public Flowable<MessageId> send(Publisher<MessageSpec<T>> messageSpecs) {
+		return Flowable.fromPublisher(this.delegate.send(messageSpecs));
+	}
+
+}

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/DefaultReactiveMessagePipeline.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/DefaultReactiveMessagePipeline.java
@@ -27,6 +27,7 @@ import org.apache.pulsar.reactive.client.api.MessageGroupingFunction;
 import org.apache.pulsar.reactive.client.api.MessageResult;
 import org.apache.pulsar.reactive.client.api.ReactiveMessageConsumer;
 import org.apache.pulsar.reactive.client.api.ReactiveMessagePipeline;
+import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
@@ -47,7 +48,7 @@ class DefaultReactiveMessagePipeline<T> implements ReactiveMessagePipeline {
 
 	private final Mono<Void> pipeline;
 
-	private final Function<Message<T>, Mono<Void>> messageHandler;
+	private final Function<Message<T>, Publisher<Void>> messageHandler;
 
 	private final BiConsumer<Message<T>, Throwable> errorLogger;
 
@@ -55,7 +56,7 @@ class DefaultReactiveMessagePipeline<T> implements ReactiveMessagePipeline {
 
 	private final Duration handlingTimeout;
 
-	private final Function<Flux<Message<T>>, Flux<MessageResult<Void>>> streamingMessageHandler;
+	private final Function<Flux<Message<T>>, Publisher<MessageResult<Void>>> streamingMessageHandler;
 
 	private final int concurrency;
 
@@ -64,9 +65,9 @@ class DefaultReactiveMessagePipeline<T> implements ReactiveMessagePipeline {
 	private final MessageGroupingFunction groupingFunction;
 
 	DefaultReactiveMessagePipeline(ReactiveMessageConsumer<T> messageConsumer,
-			Function<Message<T>, Mono<Void>> messageHandler, BiConsumer<Message<T>, Throwable> errorLogger,
-			Retry pipelineRetrySpec, Duration handlingTimeout, Function<Mono<Void>, Mono<Void>> transformer,
-			Function<Flux<Message<T>>, Flux<MessageResult<Void>>> streamingMessageHandler,
+			Function<Message<T>, Publisher<Void>> messageHandler, BiConsumer<Message<T>, Throwable> errorLogger,
+			Retry pipelineRetrySpec, Duration handlingTimeout, Function<Mono<Void>, Publisher<Void>> transformer,
+			Function<Flux<Message<T>>, Publisher<MessageResult<Void>>> streamingMessageHandler,
 			MessageGroupingFunction groupingFunction, int concurrency, int maxInflight) {
 		this.messageHandler = messageHandler;
 		this.errorLogger = errorLogger;
@@ -76,7 +77,7 @@ class DefaultReactiveMessagePipeline<T> implements ReactiveMessagePipeline {
 		this.groupingFunction = groupingFunction;
 		this.concurrency = concurrency;
 		this.maxInflight = maxInflight;
-		this.pipeline = messageConsumer.consumeMessages(this::createMessageConsumer).then().transform(transformer)
+		this.pipeline = Flux.from(messageConsumer.consume(this::createMessageConsumer)).then().transform(transformer)
 				.transform(this::decoratePipeline);
 	}
 
@@ -109,7 +110,8 @@ class DefaultReactiveMessagePipeline<T> implements ReactiveMessagePipeline {
 		}
 	}
 
-	private Flux<MessageResult<Void>> createMessageConsumer(Flux<Message<T>> messageFlux) {
+	private Flux<MessageResult<Void>> createMessageConsumer(Publisher<Message<T>> messages) {
+		Flux<Message<T>> messageFlux = Flux.from(messages);
 		if (this.messageHandler != null) {
 			if (this.streamingMessageHandler != null) {
 				throw new IllegalStateException(
@@ -130,13 +132,13 @@ class DefaultReactiveMessagePipeline<T> implements ReactiveMessagePipeline {
 			}
 		}
 		else {
-			return Objects.requireNonNull(this.streamingMessageHandler,
-					"streamingMessageHandler or messageHandler must be set").apply(messageFlux);
+			return Flux.from(Objects.requireNonNull(this.streamingMessageHandler,
+					"streamingMessageHandler or messageHandler must be set").apply(messageFlux));
 		}
 	}
 
 	private Mono<MessageResult<Void>> handleMessage(Message<T> message) {
-		return this.messageHandler.apply(message).transform(this::decorateMessageHandler)
+		return Mono.from(this.messageHandler.apply(message)).transform(this::decorateMessageHandler)
 				.thenReturn(MessageResult.acknowledge(message.getMessageId())).onErrorResume((throwable) -> {
 					if (this.errorLogger != null) {
 						try {
@@ -192,7 +194,7 @@ class DefaultReactiveMessagePipeline<T> implements ReactiveMessagePipeline {
 	}
 
 	@Override
-	public void close() throws Exception {
+	public void close() {
 		stop();
 	}
 

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/DefaultReactiveMessagePipelineBuilder.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/DefaultReactiveMessagePipelineBuilder.java
@@ -153,7 +153,7 @@ class DefaultReactiveMessagePipelineBuilder<T>
 
 	@Override
 	public ReactiveMessagePipeline build() {
-		return new DefaultReactiveMessagePipeline(this.messageConsumer, this.messageHandler, this.errorLogger,
+		return new DefaultReactiveMessagePipeline<>(this.messageConsumer, this.messageHandler, this.errorLogger,
 				this.pipelineRetrySpec, this.handlingTimeout, this.transformer, this.streamingMessageHandler,
 				this.groupingFunction, this.concurrency, this.maxInflight);
 	}


### PR DESCRIPTION
Fixes #10 

* Make ReactiveMessageSender use only rs Publisher
* Added methods to convert to Reactor and RxJava impls
* RxJava 3 dep added as compileOnly