### PR TITLE
Configure SingletonPulsarContainer with acknowledgmentAtBatchIndexLevelEnabled=true

### DIFF
--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/SingletonPulsarContainer.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/SingletonPulsarContainer.java
@@ -29,7 +29,8 @@ public final class SingletonPulsarContainer {
 
 	/** The singleton instance for Pulsar container. */
 	public static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(
-			DockerImageName.parse("apachepulsar/pulsar").withTag("2.10.1"));
+			DockerImageName.parse("apachepulsar/pulsar").withTag("2.10.1"))
+					.withEnv("PULSAR_PREFIX_acknowledgmentAtBatchIndexLevelEnabled", "true");
 
 	static {
 		PULSAR_CONTAINER.start();


### PR DESCRIPTION
- See https://pulsar.apache.org/docs/concepts-messaging/#batching
  - By default, batch index acknowledgement is disabled
- For Pulsar standalone, Environment variable must be prefixed with `PULSAR_PREFIX_` since the configuration key `acknowledgmentAtBatchIndexLevelEnabled` is missing from default `conf/standalone.conf`