### PR TITLE
Move ReactivePulsarClient::messagePipeline to ReactiveMessageConsumer

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -191,7 +191,7 @@ With `.endOfStreamAction(EndOfStreamAction.POLL)` the Reader will poll for new m
 [source,java]
 ----
 ReactiveMessageHandler reactiveMessagePipeline=
-	reactivePulsarClient
+	ReactivePulsarClient
         .messagePipeline(reactivePulsarClient
            .messageConsumer(Schema.STRING)
            .subscriptionName("sub")

--- a/README.adoc
+++ b/README.adoc
@@ -190,13 +190,13 @@ With `.endOfStreamAction(EndOfStreamAction.POLL)` the Reader will poll for new m
 
 [source,java]
 ----
-ReactiveMessageHandler reactiveMessagePipeline=
-	ReactivePulsarClient
-        .messagePipeline(reactivePulsarClient
-           .messageConsumer(Schema.STRING)
-           .subscriptionName("sub")
-           .topic(topicName)
-           .build())
+ReactiveMessageHandler reactiveMessagePipeline =
+    reactivePulsarClient
+        .messageConsumer(Schema.STRING)
+        .subscriptionName("sub")
+        .topic(topicName)
+        .build()
+        .messagePipeline()
         .messageHandler(message -> Mono.fromRunnable(()->{
             System.out.println(message.getValue());
         }))

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessagePipelineE2ETest.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessagePipelineE2ETest.java
@@ -73,7 +73,7 @@ public class ReactiveMessagePipelineE2ETest {
 			List<String> messages = Collections.synchronizedList(new ArrayList<>());
 			CountDownLatch latch = new CountDownLatch(100);
 
-			try (ReactiveMessagePipeline reactiveMessagePipeline = reactivePulsarClient
+			try (ReactiveMessagePipeline reactiveMessagePipeline = ReactivePulsarClient
 					.messagePipeline(reactivePulsarClient.messageConsumer(Schema.STRING).subscriptionName("sub")
 							.topic(topicName).build())
 					.messageHandler((message) -> Mono.fromRunnable(() -> {
@@ -110,7 +110,7 @@ public class ReactiveMessagePipelineE2ETest {
 			List<Integer> orderedSequence = IntStream.rangeClosed(1, ITEMS_PER_KEY_COUNT).boxed()
 					.collect(Collectors.toList());
 
-			ReactiveMessagePipelineBuilder.OneByOneMessagePipelineBuilder<Integer> reactiveMessageHandlerBuilder = reactivePulsarClient
+			ReactiveMessagePipelineBuilder.OneByOneMessagePipelineBuilder<Integer> reactiveMessageHandlerBuilder = ReactivePulsarClient
 					.messagePipeline(reactivePulsarClient.messageConsumer(Schema.INT32).subscriptionName("sub")
 							.topic(topicName).build())
 					.messageHandler((message) -> {

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessagePipelineE2ETest.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessagePipelineE2ETest.java
@@ -73,9 +73,8 @@ public class ReactiveMessagePipelineE2ETest {
 			List<String> messages = Collections.synchronizedList(new ArrayList<>());
 			CountDownLatch latch = new CountDownLatch(100);
 
-			try (ReactiveMessagePipeline reactiveMessagePipeline = ReactivePulsarClient
-					.messagePipeline(reactivePulsarClient.messageConsumer(Schema.STRING).subscriptionName("sub")
-							.topic(topicName).build())
+			try (ReactiveMessagePipeline reactiveMessagePipeline = reactivePulsarClient.messageConsumer(Schema.STRING)
+					.subscriptionName("sub").topic(topicName).build().messagePipeline()
 					.messageHandler((message) -> Mono.fromRunnable(() -> {
 						messages.add(message.getValue());
 						latch.countDown();
@@ -110,9 +109,8 @@ public class ReactiveMessagePipelineE2ETest {
 			List<Integer> orderedSequence = IntStream.rangeClosed(1, ITEMS_PER_KEY_COUNT).boxed()
 					.collect(Collectors.toList());
 
-			ReactiveMessagePipelineBuilder.OneByOneMessagePipelineBuilder<Integer> reactiveMessageHandlerBuilder = ReactivePulsarClient
-					.messagePipeline(reactivePulsarClient.messageConsumer(Schema.INT32).subscriptionName("sub")
-							.topic(topicName).build())
+			ReactiveMessagePipelineBuilder.OneByOneMessagePipelineBuilder<Integer> reactiveMessageHandlerBuilder = reactivePulsarClient
+					.messageConsumer(Schema.INT32).subscriptionName("sub").topic(topicName).build().messagePipeline()
 					.messageHandler((message) -> {
 						Mono<Void> messageHandler = Mono.fromRunnable(() -> {
 							Integer keyId = Integer.parseInt(message.getProperty("keyId"));

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageConsumer.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageConsumer.java
@@ -19,6 +19,7 @@ package org.apache.pulsar.reactive.client.api;
 import java.util.function.Function;
 
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.reactive.client.internal.api.ApiImplementationFactory;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -28,6 +29,14 @@ public interface ReactiveMessageConsumer<T> {
 	<R> Mono<R> consumeOne(Function<Mono<Message<T>>, Publisher<MessageResult<R>>> messageHandler);
 
 	<R> Flux<R> consumeMany(Function<Flux<Message<T>>, Publisher<MessageResult<R>>> messageHandler);
+
+	/**
+	 * Creates a builder for building a {@link ReactiveMessagePipeline}.
+	 * @return a builder for building a {@link ReactiveMessagePipeline}
+	 */
+	default ReactiveMessagePipelineBuilder<T> messagePipeline() {
+		return ApiImplementationFactory.createReactiveMessageHandlerPipelineBuilder(this);
+	}
 
 	/**
 	 * Creates the Pulsar Consumer and immediately closes it. This is useful for creating

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactivePulsarClient.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactivePulsarClient.java
@@ -61,7 +61,7 @@ public interface ReactivePulsarClient {
 	 * @param <T> the message payload type
 	 * @return a builder for building a {@link ReactiveMessagePipeline}
 	 */
-	default <T> ReactiveMessagePipelineBuilder<T> messagePipeline(ReactiveMessageConsumer<T> messageConsumer) {
+	static <T> ReactiveMessagePipelineBuilder<T> messagePipeline(ReactiveMessageConsumer<T> messageConsumer) {
 		return ApiImplementationFactory.createReactiveMessageHandlerPipelineBuilder(messageConsumer);
 	}
 

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactivePulsarClient.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactivePulsarClient.java
@@ -17,14 +17,12 @@
 package org.apache.pulsar.reactive.client.api;
 
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.reactive.client.internal.api.ApiImplementationFactory;
 
 /**
  * Apache Pulsar Reactive Client interface
  *
  * Contains methods to create builders for {@link ReactiveMessageSender},
- * {@link ReactiveMessageReader} {@link ReactiveMessageConsumer} and
- * {@link ReactiveMessagePipeline} instances.
+ * {@link ReactiveMessageReader} and {@link ReactiveMessageConsumer} instances.
  *
  * @author Lari Hotari
  */
@@ -53,16 +51,5 @@ public interface ReactivePulsarClient {
 	 * @return a builder for building a {@link ReactiveMessageConsumer}
 	 */
 	<T> ReactiveMessageConsumerBuilder<T> messageConsumer(Schema<T> schema);
-
-	/**
-	 * Creates a builder for building a {@link ReactiveMessagePipeline}.
-	 * @param messageConsumer the {@link ReactiveMessageConsumer} instance to run in the
-	 * pipeline
-	 * @param <T> the message payload type
-	 * @return a builder for building a {@link ReactiveMessagePipeline}
-	 */
-	static <T> ReactiveMessagePipelineBuilder<T> messagePipeline(ReactiveMessageConsumer<T> messageConsumer) {
-		return ApiImplementationFactory.createReactiveMessageHandlerPipelineBuilder(messageConsumer);
-	}
 
 }


### PR DESCRIPTION
So it's not needed to have access to an instance of `ReactivePulsarClient` to create a pipeline.
See https://github.com/spring-projects-experimental/spring-pulsar/pull/198#discussion_r1017238347