### PR TITLE
Be more explicit in the topic setters names of the consumer/reader builders

### DIFF
--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessageConsumerE2ETest.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessageConsumerE2ETest.java
@@ -51,7 +51,7 @@ public class ReactiveMessageConsumerE2ETest {
 			messageSender.sendMany(Flux.range(1, 100).map(Object::toString).map(MessageSpec::of)).blockLast();
 
 			ReactiveMessageConsumer<String> messageConsumer = reactivePulsarClient.messageConsumer(Schema.STRING)
-					.topic(topicName).subscriptionName("sub").build();
+					.addTopics(topicName).subscriptionName("sub").build();
 			List<String> messages = messageConsumer
 					.consumeMany((messageFlux) -> messageFlux
 							.map((message) -> MessageResult.acknowledge(message.getMessageId(), message.getValue())))

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessagePipelineE2ETest.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessagePipelineE2ETest.java
@@ -74,7 +74,7 @@ public class ReactiveMessagePipelineE2ETest {
 			CountDownLatch latch = new CountDownLatch(100);
 
 			try (ReactiveMessagePipeline reactiveMessagePipeline = reactivePulsarClient.messageConsumer(Schema.STRING)
-					.subscriptionName("sub").topic(topicName).build().messagePipeline()
+					.subscriptionName("sub").addTopics(topicName).build().messagePipeline()
 					.messageHandler((message) -> Mono.fromRunnable(() -> {
 						messages.add(message.getValue());
 						latch.countDown();
@@ -110,8 +110,8 @@ public class ReactiveMessagePipelineE2ETest {
 					.collect(Collectors.toList());
 
 			ReactiveMessagePipelineBuilder.OneByOneMessagePipelineBuilder<Integer> reactiveMessageHandlerBuilder = reactivePulsarClient
-					.messageConsumer(Schema.INT32).subscriptionName("sub").topic(topicName).build().messagePipeline()
-					.messageHandler((message) -> {
+					.messageConsumer(Schema.INT32).subscriptionName("sub").addTopics(topicName).build()
+					.messagePipeline().messageHandler((message) -> {
 						Mono<Void> messageHandler = Mono.fromRunnable(() -> {
 							Integer keyId = Integer.parseInt(message.getProperty("keyId"));
 							messages.compute(keyId, (k, list) -> {

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessageReaderE2ETest.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessageReaderE2ETest.java
@@ -49,7 +49,7 @@ public class ReactiveMessageReaderE2ETest {
 			messageSender.sendMany(Flux.range(1, 100).map(Object::toString).map(MessageSpec::of)).blockLast();
 
 			ReactiveMessageReader<String> messageReader = reactivePulsarClient.messageReader(Schema.STRING)
-					.topic(topicName).build();
+					.addTopics(topicName).build();
 			List<String> messages = messageReader.readMany().map(Message::getValue).collectList().block();
 
 			assertThat(messages).isEqualTo(Flux.range(1, 100).map(Object::toString).collectList().block());

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageConsumerBuilder.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageConsumerBuilder.java
@@ -43,19 +43,14 @@ public interface ReactiveMessageConsumerBuilder<T> {
 
 	MutableReactiveMessageConsumerSpec getMutableSpec();
 
-	default ReactiveMessageConsumerBuilder<T> topic(String topicName) {
-		getMutableSpec().getTopicNames().add(topicName);
-		return this;
-	}
-
-	default ReactiveMessageConsumerBuilder<T> topic(String... topicNames) {
+	default ReactiveMessageConsumerBuilder<T> addTopics(String... topicNames) {
 		for (String topicName : topicNames) {
 			getMutableSpec().getTopicNames().add(topicName);
 		}
 		return this;
 	}
 
-	default ReactiveMessageConsumerBuilder<T> topicNames(List<String> topicNames) {
+	default ReactiveMessageConsumerBuilder<T> topics(List<String> topicNames) {
 		getMutableSpec().setTopicNames(topicNames);
 		return this;
 	}

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageReaderBuilder.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageReaderBuilder.java
@@ -41,19 +41,14 @@ public interface ReactiveMessageReaderBuilder<T> {
 
 	ReactiveMessageReader<T> build();
 
-	default ReactiveMessageReaderBuilder<T> topic(String topicName) {
-		getMutableSpec().getTopicNames().add(topicName);
-		return this;
-	}
-
-	default ReactiveMessageReaderBuilder<T> topic(String... topicNames) {
+	default ReactiveMessageReaderBuilder<T> addTopics(String... topicNames) {
 		for (String topicName : topicNames) {
 			getMutableSpec().getTopicNames().add(topicName);
 		}
 		return this;
 	}
 
-	default ReactiveMessageReaderBuilder<T> topicNames(List<String> topicNames) {
+	default ReactiveMessageReaderBuilder<T> topics(List<String> topicNames) {
 		getMutableSpec().setTopicNames(topicNames);
 		return this;
 	}

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageSenderBuilder.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageSenderBuilder.java
@@ -17,6 +17,7 @@
 package org.apache.pulsar.reactive.client.api;
 
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -170,6 +171,14 @@ public interface ReactiveMessageSenderBuilder<T> {
 
 	default ReactiveMessageSenderBuilder<T> lazyStartPartitionedProducers(boolean lazyStartPartitionedProducers) {
 		getMutableSpec().setLazyStartPartitionedProducers(lazyStartPartitionedProducers);
+		return this;
+	}
+
+	default ReactiveMessageSenderBuilder<T> property(String key, String value) {
+		if (getMutableSpec().getProperties() == null) {
+			getMutableSpec().setProperties(new LinkedHashMap<>());
+		}
+		getMutableSpec().getProperties().put(key, value);
 		return this;
 	}
 


### PR DESCRIPTION
* Replace `topic(String...)` by `addTopics(String...)`
* Remove `topic(String)` as it's redundant with `addTopics(String...)` where you only provide one arg.
* Add `property(String, String)` to the sender builder for consistency with the consumer builder.