### PR TITLE
Fix bugs in InflightLimiter and add tests

### DIFF
--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/InflightLimiter.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/InflightLimiter.java
@@ -36,6 +36,14 @@ import reactor.util.context.Context;
 /**
  * Transformer class that limits the number of reactive streams subscription requests to
  * keep the number of pending messages under a defined limit.
+ *
+ * Subscribing to upstream is postponed if the max inflight limit is reached since
+ * subscribing to a CompletableFuture is eager. The CompetableFuture will be created at
+ * subscription time and this demand cannot be controlled with Reactive Stream's requests.
+ * The solution for this is to acquire one slot at subscription time and return this slot
+ * when request is made to the subscription. Since it's not possible to backpressure the
+ * subscription requests, there's a configurable limit for the total number of pending
+ * subscriptions. Exceeding the limit will cause IllegalStateException at runtime.
  */
 public class InflightLimiter implements PublisherTransformer {
 

--- a/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipelineTest.java
+++ b/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipelineTest.java
@@ -319,7 +319,7 @@ class ReactiveMessagePipelineTest {
 		try (ReactiveMessagePipeline pipeline = testConsumer.messagePipeline().messageHandler(messageHandler2)
 				.concurrency(1000).maxInflight(maxInFlight).build()) {
 			pipeline.start();
-			assertThat(latch.await(3, TimeUnit.SECONDS)).isTrue();
+			assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
 			assertThat(inflightCounter.getMax()).isEqualTo(maxInFlight);
 		}
 	}

--- a/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/internal/api/InflightLimiterTest.java
+++ b/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/internal/api/InflightLimiterTest.java
@@ -72,8 +72,6 @@ class InflightLimiterTest {
 					});
 				}).doOnNext((__) -> {
 					worker.schedule(() -> {
-						currentRequests.decrementAndGet();
-						totalRequests.decrementAndGet();
 						subscriptionsActiveBeforeCompletingFirstElement.decrementAndGet();
 						// Mono will complete after this element, so reduce all remaining
 						// requests;

--- a/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/internal/api/InflightLimiterTest.java
+++ b/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/internal/api/InflightLimiterTest.java
@@ -16,50 +16,174 @@
 
 package org.apache.pulsar.reactive.client.internal.api;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler.Worker;
 import reactor.core.scheduler.Schedulers;
-import reactor.test.StepVerifier;
+import reactor.util.function.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class InflightLimiterTest {
 
-	@Test
-	void shouldLimitInflight() {
-		List<Integer> values = Collections.synchronizedList(new ArrayList<>());
-		InflightLimiter inflightLimiter = new InflightLimiter(48, 24, Schedulers.single(),
+	@ParameterizedTest
+	@CsvSource({ "7,100", "13,100", "37,500", "51,1000" })
+	void shouldNotRequestOrSubscribeMoreThanMaxInflightForMonos(int maxInflight, int maxElements) {
+		InflightLimiter inflightLimiter = new InflightLimiter(maxInflight, maxInflight, Schedulers.single(),
 				InflightLimiter.DEFAULT_MAX_PENDING_SUBSCRIPTIONS);
-		Flux.merge(Arrays.asList(
-				Flux.range(1, 100).publishOn(Schedulers.parallel()).log().as(inflightLimiter::createOperator),
-				Flux.range(101, 100).publishOn(Schedulers.parallel()).log().as(inflightLimiter::createOperator),
-				Flux.range(201, 100).publishOn(Schedulers.parallel()).log().as(inflightLimiter::createOperator)))
-				.as(StepVerifier::create).expectSubscription().recordWith(() -> values).expectNextCount(300)
-				.expectComplete().verify();
-		assertThat(values)
-				.containsExactlyInAnyOrderElementsOf(IntStream.range(1, 301).boxed().collect(Collectors.toList()));
-		// verify "fairness"
-		// TODO: this is flaky, fix it
-		// verifyFairness(values);
+
+		AtomicLong totalRequests = new AtomicLong();
+		AtomicLong requestsMax = new AtomicLong();
+		AtomicInteger subscriptionsActiveBeforeCompletingFirstElement = new AtomicInteger();
+		AtomicInteger subscriptionsMax = new AtomicInteger();
+
+		List<Integer> inputValues = IntStream.rangeClosed(1, maxElements).boxed().collect(Collectors.toList());
+
+		Worker worker = Schedulers.boundedElastic().createWorker();
+		try {
+			Flux<Integer> flux = Flux.fromIterable(inputValues).flatMap((i) -> {
+				AtomicLong currentRequests = new AtomicLong();
+				return Mono.delay(Duration.ofMillis(25L)).thenReturn(i).doOnSubscribe((subscription) -> {
+					worker.schedule(() -> {
+						int currentSubscriptionsCount = subscriptionsActiveBeforeCompletingFirstElement
+								.incrementAndGet();
+						subscriptionsMax.accumulateAndGet(currentSubscriptionsCount, Math::max);
+					});
+				}).doOnRequest((requested) -> {
+					worker.schedule(() -> {
+						currentRequests.addAndGet(requested);
+						long current = totalRequests.addAndGet(requested);
+						requestsMax.accumulateAndGet(current, Math::max);
+					});
+				}).doOnNext((__) -> {
+					worker.schedule(() -> {
+						currentRequests.decrementAndGet();
+						totalRequests.decrementAndGet();
+						subscriptionsActiveBeforeCompletingFirstElement.decrementAndGet();
+						// Mono will complete after this element, so reduce all remaining
+						// requests;
+						totalRequests.addAndGet(-currentRequests.getAndSet(0));
+					});
+				}).transform(inflightLimiter::transform).subscribeOn(Schedulers.single());
+			}, maxElements);
+			List<Integer> values = flux.collectList().block();
+			SoftAssertions.assertSoftly((softly) -> {
+				softly.assertThat(values).containsExactlyInAnyOrderElementsOf(inputValues);
+				softly.assertThat(requestsMax.get()).as("requestsMax").isEqualTo(maxInflight);
+				softly.assertThat(subscriptionsMax.get()).as("subscriptionsMax").isEqualTo(maxInflight);
+			});
+		}
+		finally {
+			worker.dispose();
+		}
 	}
 
-	private void verifyFairness(List<Integer> values) {
-		int previousValue = 1;
-		for (int i = 0; i < values.size(); i++) {
-			int value = values.get(i) % 100;
-			if (value == 0) {
-				value = 100;
-			}
-			assertThat(Math.abs(previousValue - value)).as("value %d at index %d", values.get(i), i)
-					.isLessThanOrEqualTo(48);
-			previousValue = value;
+	@ParameterizedTest
+	@CsvSource({ "7,100", "13,100", "37,500", "51,1000" })
+	void shouldNotSubscribeMoreThanMaxInflightForMonos(int maxInflight, int maxElements) {
+		InflightLimiter inflightLimiter = new InflightLimiter(maxInflight, maxInflight, Schedulers.single(),
+				InflightLimiter.DEFAULT_MAX_PENDING_SUBSCRIPTIONS);
+
+		AtomicInteger completableFuturesInflight = new AtomicInteger();
+		AtomicInteger completableFuturesInflightMax = new AtomicInteger();
+
+		List<Integer> inputValues = IntStream.rangeClosed(1, maxElements).boxed().collect(Collectors.toList());
+
+		Flux<Integer> flux = Flux.fromIterable(inputValues).flatMap((i) -> Mono.fromCompletionStage(() -> {
+			completableFuturesInflightMax.accumulateAndGet(completableFuturesInflight.incrementAndGet(), Math::max);
+			CompletableFuture<Integer> future = new CompletableFuture<>();
+			Schedulers.boundedElastic().schedule(() -> {
+				completableFuturesInflight.decrementAndGet();
+				future.complete(i);
+			}, 5, TimeUnit.MILLISECONDS);
+			return future;
+		}).transform(inflightLimiter::transform).subscribeOn(Schedulers.parallel()), maxElements);
+
+		List<Integer> values = flux.collectList().block();
+		assertThat(values).containsExactlyInAnyOrderElementsOf(inputValues);
+		assertThat(completableFuturesInflightMax.get()).isEqualTo(maxInflight);
+	}
+
+	@Disabled("This test was used to debug the flakiness issue")
+	@RepeatedTest(100)
+	void repeatShouldNotSubscribeMoreThanMaxInflightForMonos() {
+		shouldNotSubscribeMoreThanMaxInflightForMonos(7, 100);
+		shouldNotRequestOrSubscribeMoreThanMaxInflightForMonos(7, 100);
+		shouldNotRequestOrSubscribeMoreThanMaxInflightForFluxes(7, 100);
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "7,100", "13,100", "37,500", "51,1000" })
+	void shouldNotRequestOrSubscribeMoreThanMaxInflightForFluxes(int maxInflight, int maxElements) {
+		int subfluxSize = 3;
+
+		InflightLimiter inflightLimiter = new InflightLimiter(maxInflight, maxInflight, Schedulers.single(),
+				InflightLimiter.DEFAULT_MAX_PENDING_SUBSCRIPTIONS);
+
+		AtomicLong totalRequests = new AtomicLong();
+		AtomicLong requestsMax = new AtomicLong();
+		AtomicInteger subscriptionsActiveBeforeCompletingFirstElement = new AtomicInteger();
+		AtomicInteger subscriptionsMax = new AtomicInteger();
+
+		List<Integer> inputValues = IntStream.rangeClosed(1, maxElements).boxed().collect(Collectors.toList());
+
+		Flux<Integer> flux = Flux.fromIterable(inputValues).window(subfluxSize).flatMap((subFlux) -> {
+			AtomicLong currentRequests = new AtomicLong();
+			return subFlux.flatMap((i) -> Mono.delay(Duration.ofMillis(25L)).thenReturn(i)).index()
+					.doOnSubscribe((subscription) -> {
+						int currentSubscriptionsCount = subscriptionsActiveBeforeCompletingFirstElement
+								.incrementAndGet();
+						subscriptionsMax.accumulateAndGet(currentSubscriptionsCount, Math::max);
+					}).doOnRequest((requested) -> {
+						currentRequests.addAndGet(requested);
+						long current = totalRequests.addAndGet(requested);
+						requestsMax.accumulateAndGet(current, Math::max);
+					}).doOnNext((indexed) -> {
+						currentRequests.decrementAndGet();
+						totalRequests.decrementAndGet();
+						if (indexed.getT1() == 0L) {
+							subscriptionsActiveBeforeCompletingFirstElement.decrementAndGet();
+						}
+					}).doFinally((__) -> totalRequests.addAndGet(-currentRequests.getAndSet(0)))
+					.transform(inflightLimiter::transform).subscribeOn(Schedulers.parallel());
+		}, maxElements).map(Tuple2::getT2);
+
+		List<Integer> values = flux.collectList().block();
+		assertThat(values).containsExactlyInAnyOrderElementsOf(inputValues);
+		assertThat(requestsMax.get()).isEqualTo(maxInflight);
+		assertThat(subscriptionsMax.get()).isEqualTo(maxInflight);
+	}
+
+	@Test
+	void shouldSpreadRequestsEvenlyAcrossUpstream() {
+		InflightLimiter inflightLimiter = new InflightLimiter(1, 1, Schedulers.single(),
+				InflightLimiter.DEFAULT_MAX_PENDING_SUBSCRIPTIONS);
+		List<Integer> values = Flux
+				.merge(100, Flux.range(1, 100).delayElements(Duration.ofMillis(1)).as(inflightLimiter::createOperator),
+						Flux.range(101, 100).delayElements(Duration.ofMillis(1)).as(inflightLimiter::createOperator),
+						Flux.range(201, 100).delayElements(Duration.ofMillis(1)).as(inflightLimiter::createOperator))
+				.collectList().block();
+		assertThat(values).containsExactlyInAnyOrderElementsOf(
+				IntStream.rangeClosed(1, 300).boxed().collect(Collectors.toList()));
+		for (int i = 0; i < 100; i = i + 3) {
+			assertThat(new int[] { values.get(i), values.get(i + 1), values.get(i + 2) })
+					.containsExactly(values.get(i), values.get(i) + 100, values.get(i) + 200)
+					.as("values at index %d-%d", i, i + 2);
 		}
 	}
 


### PR DESCRIPTION
- InflightLimiter has some bugs in max request calculation. The logic was hard to understand and this PR also simplifies the code.

- InflightLimiter's maybeTriggerNext unnecessarily scheduled tasks on every emitted entry. This has been optimized.
  - Optimize maybeTriggerNext to schedule a job only when there's pendingSubscriptions and there's a need to request more elements.
  - An additional optimization was added to maybeTriggerNext scheduling that there will only be one job triggered at a time when the condition is true.
  
- test that requests or subscriptions don't go over the maxInflight limit
    - the reason why subscriptions should also be limited is that if there are non-lazy Mono's that already do work at subscription time, the maxInflight limit wouldn't be effective. This is the case with CompletableFutures that are adapted to Mono.
    - It is valid that active subscriptions go over the limit, it's only subscribing that is limited. In testing, the number of subscriptions before completing the first element should be limited.
