### PR TITLE
Require cache when maxInflight is set for ReactiveMessageSenderBuilder

### DIFF
--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessageSenderE2ETest.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessageSenderE2ETest.java
@@ -62,7 +62,7 @@ class ReactiveMessageSenderE2ETest {
 				ReactivePulsarClient reactivePulsarClient = AdaptedReactivePulsarClientFactory.create(pulsarClient);
 
 				ReactiveMessageSender<String> messageSender = reactivePulsarClient.messageSender(Schema.STRING)
-						.topic(topicName).maxInflight(1).build();
+						.topic(topicName).build();
 				MessageId messageId = messageSender.sendOne(MessageSpec.of("Hello world!")).block();
 				assertThat(messageId).isNotNull();
 

--- a/pulsar-client-reactive-adapter/src/main/java/org/apache/pulsar/reactive/client/internal/adapter/AdaptedReactiveMessageSenderBuilder.java
+++ b/pulsar-client-reactive-adapter/src/main/java/org/apache/pulsar/reactive/client/internal/adapter/AdaptedReactiveMessageSenderBuilder.java
@@ -99,6 +99,7 @@ class AdaptedReactiveMessageSenderBuilder<T> implements ReactiveMessageSenderBui
 	public ReactiveMessageSender<T> build() {
 		Object producerActionTransformerKey;
 		if (this.maxInflight > 0) {
+			Objects.requireNonNull(this.producerCache, "cache must be provided when maxInflight is set.");
 			this.producerActionTransformer = () -> new InflightLimiter(this.maxInflight,
 					Math.max(this.maxInflight / 2, 1), Schedulers.single(), this.maxConcurrentSenderSubscriptions);
 			producerActionTransformerKey = new ProducerActionTransformerKey(this.maxInflight,


### PR DESCRIPTION
Fixes #90