### PR TITLE
Post release 0.1.0 changes: update README, bump development version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 .idea
 .project
 .settings
+bin/

--- a/README.adoc
+++ b/README.adoc
@@ -25,22 +25,14 @@ This uses Project Reactor as the Reactive Streams implementation.
 
 == Getting it
 
-There is no release available yet. Snapshot builds are published to Apache snapshot repository, https://repository.apache.org/content/repositories/snapshots.
-
 *This library requires Java 8 or + to run*.
 
 With Gradle:
 
 [source,groovy]
 ----
-repositories {
-    maven {
-        url 'https://repository.apache.org/content/repositories/snapshots'
-	}
-}
-
 dependencies {
-    implementation "org.apache.pulsar:pulsar-client-reactive-adapter:0.1.0-SNAPSHOT"
+    implementation "org.apache.pulsar:pulsar-client-reactive-adapter:0.1.0"
 }
 ----
 
@@ -48,23 +40,11 @@ With Maven:
 
 [source,xml]
 ----
-<repository>
-	<id>apache.snapshots</id>
-	<name>Apache Development Snapshot Repository</name>
-	<url>https://repository.apache.org/content/repositories/snapshots/</url>
-	<releases>
-		<enabled>false</enabled>
-	</releases>
-	<snapshots>
-		<enabled>true</enabled>
-	</snapshots>
-</repository>
-
 <dependencies>
     <dependency>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-client-reactive-adapter</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
     </dependency>
 </dependencies>
 ----
@@ -106,8 +86,8 @@ Adding Caffeine based producer cache with Gradle:
 [source,groovy]
 ----
 dependencies {
-    implementation "org.apache.pulsar:pulsar-client-reactive-adapter:0.1.0-SNAPSHOT"
-    implementation "org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine:0.1.0-SNAPSHOT"
+    implementation "org.apache.pulsar:pulsar-client-reactive-adapter:0.1.0"
+    implementation "org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine:0.1.0"
 }
 ----
 
@@ -119,12 +99,12 @@ Adding Caffeine based producer cache with Maven:
     <dependency>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-client-reactive-adapter</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-client-reactive-producer-cache-caffeine</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
     </dependency>
 </dependencies>
 ----
@@ -177,7 +157,7 @@ With `.endOfStreamAction(EndOfStreamAction.POLL)` the Reader will poll for new m
     ReactiveMessageReader<String> messageReader =
             reactivePulsarClient.messageReader(Schema.STRING)
                     .topic(topicName)
-                    .startAtSpec(StartAtSpec.LATEST)
+                    .startAtSpec(StartAtSpec.ofLatest())
                     .endOfStreamAction(EndOfStreamAction.POLL)
                     .build();
     messageReader.readMany()
@@ -208,7 +188,7 @@ With `.endOfStreamAction(EndOfStreamAction.POLL)` the Reader will poll for new m
 
 [source,java]
 ----
-ReactiveMessageHandler reactiveMessagePipeline =
+ReactiveMessagePipeline reactiveMessagePipeline =
     reactivePulsarClient
         .messageConsumer(Schema.STRING)
         .subscriptionName("sub")

--- a/README.adoc
+++ b/README.adoc
@@ -19,6 +19,7 @@
 = Reactive client for Apache Pulsar
 
 :github: https://github.com/apache/pulsar-client-reactive
+:latest_version: 0.1.0
 
 Reactive client for Apache Pulsar which is compatible with the Reactive Streams specification.
 This uses Project Reactor as the Reactive Streams implementation.
@@ -29,22 +30,22 @@ This uses Project Reactor as the Reactive Streams implementation.
 
 With Gradle:
 
-[source,groovy]
+[source,groovy,subs="verbatim,attributes"]
 ----
 dependencies {
-    implementation "org.apache.pulsar:pulsar-client-reactive-adapter:0.1.0"
+    implementation "org.apache.pulsar:pulsar-client-reactive-adapter:{latest_version}"
 }
 ----
 
 With Maven:
 
-[source,xml]
+[source,xml,subs="verbatim,attributes"]
 ----
 <dependencies>
     <dependency>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-client-reactive-adapter</artifactId>
-        <version>0.1.0</version>
+        <version>{latest_version}</version>
     </dependency>
 </dependencies>
 ----
@@ -83,28 +84,28 @@ By default a ConcurrentHashMap based cache is used. It's recommended to use a mo
 
 Adding Caffeine based producer cache with Gradle:
 
-[source,groovy]
+[source,groovy,subs="verbatim,attributes"]
 ----
 dependencies {
-    implementation "org.apache.pulsar:pulsar-client-reactive-adapter:0.1.0"
-    implementation "org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine:0.1.0"
+    implementation "org.apache.pulsar:pulsar-client-reactive-adapter:{latest_version}"
+    implementation "org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine:{latest_version}"
 }
 ----
 
 Adding Caffeine based producer cache with Maven:
 
-[source,xml]
+[source,xml,subs="verbatim,attributes"]
 ----
 <dependencies>
     <dependency>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-client-reactive-adapter</artifactId>
-        <version>0.1.0</version>
+        <version>{latest_version}</version>
     </dependency>
     <dependency>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-client-reactive-producer-cache-caffeine</artifactId>
-        <version>0.1.0</version>
+        <version>{latest_version}</version>
     </dependency>
 </dependencies>
 ----

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-version=0.1.0
+version=0.1.1-SNAPSHOT


### PR DESCRIPTION
- update versions in README
- fix some code examples
- bump development version to 0.1.1-SNAPSHOT
- add `bin/` to .gitignore (IntelliJ uses bin directory if tests are run with IntelliJ instead of Gradle, that's sometimes useful)