### PR TITLE
Improve Gradle configuration in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,8 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: Check with Gradle
         run: ./gradlew rat licenseCheck javadoc check


### PR DESCRIPTION
- use https://github.com/gradle/gradle-build-action#why-use-the-gradle-build-action which contains a GitHub Actions caching solution for Gradle.