### PR TITLE
build: Upgrade Pulsar version to 3.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@
 # under the License.
 #
 [versions]
-pulsar = "2.11.0"
+pulsar = "3.0.0"
 junit-jupiter = "5.8.2"
 log4j = "2.18.0"
 slf4j = "1.7.36"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@
 # under the License.
 #
 [versions]
-pulsar = "3.0.0"
+pulsar = "3.0.1"
 junit-jupiter = "5.8.2"
 log4j = "2.18.0"
 slf4j = "1.7.36"

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/SingletonPulsarContainer.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/SingletonPulsarContainer.java
@@ -44,7 +44,7 @@ final class SingletonPulsarContainer {
 	}
 
 	static DockerImageName getPulsarImage() {
-		return DockerImageName.parse("apachepulsar/pulsar:3.0.0");
+		return DockerImageName.parse("apachepulsar/pulsar:3.0.1");
 	}
 
 }

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/SingletonPulsarContainer.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/SingletonPulsarContainer.java
@@ -19,8 +19,6 @@
 
 package org.apache.pulsar.reactive.client.adapter;
 
-import java.util.Locale;
-
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.testcontainers.containers.PulsarContainer;
@@ -46,21 +44,7 @@ final class SingletonPulsarContainer {
 	}
 
 	static DockerImageName getPulsarImage() {
-		return isRunningOnMacM1() ? getMacM1PulsarImage() : getStandardPulsarImage();
-	}
-
-	private static boolean isRunningOnMacM1() {
-		String osName = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
-		String osArchitecture = System.getProperty("os.arch").toLowerCase(Locale.ENGLISH);
-		return osName.contains("mac") && osArchitecture.equals("aarch64");
-	}
-
-	private static DockerImageName getStandardPulsarImage() {
-		return DockerImageName.parse("apachepulsar/pulsar:2.11.0");
-	}
-
-	private static DockerImageName getMacM1PulsarImage() {
-		return DockerImageName.parse("kezhenxu94/pulsar").asCompatibleSubstituteFor("apachepulsar/pulsar");
+		return DockerImageName.parse("apachepulsar/pulsar:3.0.0");
 	}
 
 }


### PR DESCRIPTION
- Update version in toml
- Simplify the docker image name in int tests as Pulsar 3.0.0 docker images are multi-architectured (no need for special Mac M1/M2 treatment).

Fixes #126

cc: @lhotari @cbornet 