### PR TITLE
Updates to Java 17 for building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,19 +35,19 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Check with Gradle
         run: ./gradlew rat licenseCheck javadoc check

--- a/buildSrc/src/main/groovy/pulsar-client-reactive.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/pulsar-client-reactive.library-conventions.gradle
@@ -30,9 +30,14 @@ repositories {
 java {
 	withJavadocJar()
 	withSourcesJar()
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(17)
+	}
 }
 
-sourceCompatibility = '8'
+compileJava {
+	options.release = 8
+}
 
 publishing {
 	repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ pulsar = "3.3.1"
 rat-gradle = "0.8.0"
 reactor = "3.6.8"
 slf4j = "2.0.13"
-spring-javaformat = "0.0.41"
+spring-javaformat = "0.0.42"
 testcontainers = "1.20.1"
 testlogger = "3.2.0"
 


### PR DESCRIPTION
This proposal updates to Java 17 for building but retains Java 8 as the language level via the `options.release` flag.

The second commit takes advantage of the first and updates the spring javaformat to `0.0.42` (which relies on Java 17 compilation).