### PR TITLE
Use slf4j2 implementation log4j-slf4j2-impl

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", vers
 licenser = { module = "gradle.plugin.org.cadixdev.gradle:licenser", version.ref = "licenser" }
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
-log4j-slf4j-impl = { module = "org.apache.logging.log4j:log4j-slf4j-impl", version.ref = "log4j" }
+log4j-slf4j2-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version.ref = "log4j" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 pulsar-client-api = { module = "org.apache.pulsar:pulsar-client-api", version.ref = "pulsar" }
 pulsar-client-shaded = { module = "org.apache.pulsar:pulsar-client", version.ref = "pulsar" }
@@ -65,7 +65,7 @@ testlogger = { module = "com.adarshr:gradle-test-logger-plugin", version.ref = "
 log4j = [
     "log4j-api",
     "log4j-core",
-    "log4j-slf4j-impl",
+    "log4j-slf4j2-impl",
     "slf4j-api",
 ]
 


### PR DESCRIPTION
Fixes this error message:
```
  SLF4J(W): No SLF4J providers were found.
  SLF4J(W): Defaulting to no-operation (NOP) logger implementation
  SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
  SLF4J(W): Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
  SLF4J(W): Ignoring binding found at [jar:file:/Users/lari/.gradle/caches/modules-2/files-2.1/org.apache.logging.log4j/log4j-slf4j-impl/2.23.1/9ef67909a1b4eae999af4c7a211ab2379e4b86c2/log4j-slf4j-impl-2.23.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
  SLF4J(W): See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```