### PR TITLE
[Release 0.5.10] Post release steps

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@
 = Reactive client for Apache Pulsar
 
 :github: https://github.com/apache/pulsar-client-reactive
-:latest_version: 0.5.8
+:latest_version: 0.5.10
 
 Reactive client for Apache Pulsar which is compatible with the Reactive Streams specification.
 This uses Project Reactor as the Reactive Streams implementation.

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-version=0.5.10
+version=0.5.11-SNAPSHOT


### PR DESCRIPTION
This performs the following post-release steps for release 0.5.10

- Update latest version in README.adoc to 0.5.10
- Update next snapshot version to 0.5.11-SNAPSHOT