### PR TITLE
#210 ReactiveMessagePipline allowing negative ack 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -328,6 +328,41 @@ Thread.sleep(10000L);
 reactiveMessagePipeline.stop();
 ----
 
+=== Consuming messages using a message handler component with redelivery
+
+For demonstration purposes, the `messageHandlerWithResult` negatively acknowledge all messages
+that are redelivered 3 times with an exponential backoff delay and finally goes to the dead letter topic.
+
+[source,java]
+----
+ReactiveMessagePipeline reactiveMessagePipeline =
+    reactivePulsarClient
+        .messageConsumer(Schema.STRING)
+        .subscriptionName("sub")
+        .topic(topicName)
+        .negativeAckRedeliveryBackoff(new ExponentialRedeliveryBackoff(2, 1500))
+        .retryLetterTopicEnable(true)
+        .deadLetterPolicy(DeadLetterPolicy.builder()
+                .maxRedeliverCount(3)
+                .retryLetterTopic(topicName+"-RETRY")
+                .deadLetterTopic(topicName+"-DLQ")
+                .initialSubscriptionName("sub")
+                .build())
+        .build()
+        .messagePipeline()
+        .messageHandlerWithResult(message -> {
+            System.out.println("message date=" + new Date() + " value=" + message.getValue());
+            return Mono.just(MessageResult.negativeAcknowledge(message.getMessageId(), message.getValue()));
+        })
+        .build()
+        .start();
+// for demonstration
+// the reactive message handler is running in the background, delay for 10 seconds
+Thread.sleep(10000L);
+// now stop the message handler component
+reactiveMessagePipeline.stop();
+----
+
 == License
 
 Reactive client for Apache Pulsar is Open Source Software released under the link:www.apache.org/licenses/LICENSE-2.0[Apache Software License 2.0].

--- a/pulsar-client-reactive-adapter/src/main/java/org/apache/pulsar/reactive/client/internal/adapter/AdaptedReactiveMessageConsumer.java
+++ b/pulsar-client-reactive-adapter/src/main/java/org/apache/pulsar/reactive/client/internal/adapter/AdaptedReactiveMessageConsumer.java
@@ -173,6 +173,12 @@ class AdaptedReactiveMessageConsumer<T> implements ReactiveMessageConsumer<T> {
 			consumerBuilder.negativeAckRedeliveryDelay(this.consumerSpec.getNegativeAckRedeliveryDelay().toMillis(),
 					TimeUnit.MILLISECONDS);
 		}
+		if (this.consumerSpec.getAckTimeoutRedeliveryBackoff() != null) {
+			consumerBuilder.ackTimeoutRedeliveryBackoff(this.consumerSpec.getAckTimeoutRedeliveryBackoff());
+		}
+		if (this.consumerSpec.getNegativeAckRedeliveryBackoff() != null) {
+			consumerBuilder.negativeAckRedeliveryBackoff(this.consumerSpec.getNegativeAckRedeliveryBackoff());
+		}
 		if (this.consumerSpec.getDeadLetterPolicy() != null) {
 			consumerBuilder.deadLetterPolicy(this.consumerSpec.getDeadLetterPolicy());
 		}

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ImmutableReactiveMessageConsumerSpec.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ImmutableReactiveMessageConsumerSpec.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.KeySharedPolicy;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
@@ -85,6 +86,10 @@ public class ImmutableReactiveMessageConsumerSpec implements ReactiveMessageCons
 	private final Scheduler acknowledgeScheduler;
 
 	private final Duration negativeAckRedeliveryDelay;
+
+	private final RedeliveryBackoff negativeAckRedeliveryBackoff;
+
+	private final RedeliveryBackoff ackTimeoutRedeliveryBackoff;
 
 	private final DeadLetterPolicy deadLetterPolicy;
 
@@ -160,6 +165,8 @@ public class ImmutableReactiveMessageConsumerSpec implements ReactiveMessageCons
 		this.acknowledgeAsynchronously = consumerSpec.getAcknowledgeAsynchronously();
 		this.acknowledgeScheduler = consumerSpec.getAcknowledgeScheduler();
 		this.negativeAckRedeliveryDelay = consumerSpec.getNegativeAckRedeliveryDelay();
+		this.negativeAckRedeliveryBackoff = consumerSpec.getNegativeAckRedeliveryBackoff();
+		this.ackTimeoutRedeliveryBackoff = consumerSpec.getAckTimeoutRedeliveryBackoff();
 
 		this.deadLetterPolicy = consumerSpec.getDeadLetterPolicy();
 
@@ -192,6 +199,7 @@ public class ImmutableReactiveMessageConsumerSpec implements ReactiveMessageCons
 			Map<String, String> properties, Integer priorityLevel, Boolean readCompacted, Boolean batchIndexAckEnabled,
 			Duration ackTimeout, Duration ackTimeoutTickTime, Duration acknowledgementsGroupTime,
 			Boolean acknowledgeAsynchronously, Scheduler acknowledgeScheduler, Duration negativeAckRedeliveryDelay,
+			RedeliveryBackoff negativeAckRedeliveryBackoff, RedeliveryBackoff ackTimeoutRedeliveryBackoff,
 			DeadLetterPolicy deadLetterPolicy, Boolean retryLetterTopicEnable, Integer receiverQueueSize,
 			Integer maxTotalReceiverQueueSizeAcrossPartitions, Boolean autoUpdatePartitions,
 			Duration autoUpdatePartitionsInterval, CryptoKeyReader cryptoKeyReader,
@@ -219,6 +227,8 @@ public class ImmutableReactiveMessageConsumerSpec implements ReactiveMessageCons
 		this.acknowledgeAsynchronously = acknowledgeAsynchronously;
 		this.acknowledgeScheduler = acknowledgeScheduler;
 		this.negativeAckRedeliveryDelay = negativeAckRedeliveryDelay;
+		this.negativeAckRedeliveryBackoff = negativeAckRedeliveryBackoff;
+		this.ackTimeoutRedeliveryBackoff = ackTimeoutRedeliveryBackoff;
 		this.deadLetterPolicy = deadLetterPolicy;
 		this.retryLetterTopicEnable = retryLetterTopicEnable;
 		this.receiverQueueSize = receiverQueueSize;
@@ -340,6 +350,16 @@ public class ImmutableReactiveMessageConsumerSpec implements ReactiveMessageCons
 	@Override
 	public Duration getNegativeAckRedeliveryDelay() {
 		return this.negativeAckRedeliveryDelay;
+	}
+
+	@Override
+	public RedeliveryBackoff getNegativeAckRedeliveryBackoff() {
+		return this.negativeAckRedeliveryBackoff;
+	}
+
+	@Override
+	public RedeliveryBackoff getAckTimeoutRedeliveryBackoff() {
+		return this.ackTimeoutRedeliveryBackoff;
 	}
 
 	@Override

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/MessageResult.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/MessageResult.java
@@ -78,8 +78,8 @@ public interface MessageResult<T> {
 	 * @param message the message to acknowledge
 	 * @return the result of the message processing
 	 */
-	static <V> MessageResult<Void> acknowledge(Message<V> message) {
-		return acknowledge(message.getMessageId());
+	static <V> MessageResult<V> acknowledge(Message<V> message) {
+		return acknowledge(message.getMessageId(), message.getValue());
 	}
 
 	/**
@@ -89,8 +89,8 @@ public interface MessageResult<T> {
 	 * @param message the message to negatively acknowledge
 	 * @return the result of the message processing
 	 */
-	static <V> MessageResult<Void> negativeAcknowledge(Message<V> message) {
-		return negativeAcknowledge(message.getMessageId());
+	static <V> MessageResult<V> negativeAcknowledge(Message<V> message) {
+		return negativeAcknowledge(message.getMessageId(), message.getValue());
 	}
 
 	/**

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/MutableReactiveMessageConsumerSpec.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/MutableReactiveMessageConsumerSpec.java
@@ -30,6 +30,7 @@ import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.KeySharedPolicy;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
@@ -84,6 +85,10 @@ public class MutableReactiveMessageConsumerSpec implements ReactiveMessageConsum
 	private Scheduler acknowledgeScheduler;
 
 	private Duration negativeAckRedeliveryDelay;
+
+	private RedeliveryBackoff negativeAckRedeliveryBackoff;
+
+	private RedeliveryBackoff ackTimeoutRedeliveryBackoff;
 
 	private DeadLetterPolicy deadLetterPolicy;
 
@@ -165,6 +170,8 @@ public class MutableReactiveMessageConsumerSpec implements ReactiveMessageConsum
 		this.acknowledgeAsynchronously = consumerSpec.getAcknowledgeAsynchronously();
 		this.acknowledgeScheduler = consumerSpec.getAcknowledgeScheduler();
 		this.negativeAckRedeliveryDelay = consumerSpec.getNegativeAckRedeliveryDelay();
+		this.negativeAckRedeliveryBackoff = consumerSpec.getNegativeAckRedeliveryBackoff();
+		this.ackTimeoutRedeliveryBackoff = consumerSpec.getAckTimeoutRedeliveryBackoff();
 
 		this.deadLetterPolicy = consumerSpec.getDeadLetterPolicy();
 
@@ -483,6 +490,32 @@ public class MutableReactiveMessageConsumerSpec implements ReactiveMessageConsum
 	}
 
 	@Override
+	public RedeliveryBackoff getAckTimeoutRedeliveryBackoff() {
+		return this.ackTimeoutRedeliveryBackoff;
+	}
+
+	/**
+	 * Sets the redelivery backoff policy for messages that are redelivered due to acknowledgement timeout.
+	 * @param ackTimeoutRedeliveryBackoff the backoff policy to use for messages that exceed their ack timeout
+	 */
+	public void setAckTimeoutRedeliveryBackoff(RedeliveryBackoff ackTimeoutRedeliveryBackoff) {
+		this.ackTimeoutRedeliveryBackoff = ackTimeoutRedeliveryBackoff;
+	}
+
+	@Override
+	public RedeliveryBackoff getNegativeAckRedeliveryBackoff() {
+		return this.negativeAckRedeliveryBackoff;
+	}
+
+	/**
+	 * Sets the redelivery backoff policy for messages that are negatively acknowledged.
+	 * @param negativeAckRedeliveryBackoff the backoff policy to use for negatively acknowledged messages
+	 */
+	public void setNegativeAckRedeliveryBackoff(RedeliveryBackoff negativeAckRedeliveryBackoff) {
+		this.negativeAckRedeliveryBackoff = negativeAckRedeliveryBackoff;
+	}
+
+	@Override
 	public DeadLetterPolicy getDeadLetterPolicy() {
 		return this.deadLetterPolicy;
 	}
@@ -704,6 +737,12 @@ public class MutableReactiveMessageConsumerSpec implements ReactiveMessageConsum
 		}
 		if (consumerSpec.getNegativeAckRedeliveryDelay() != null) {
 			setNegativeAckRedeliveryDelay(consumerSpec.getNegativeAckRedeliveryDelay());
+		}
+		if (consumerSpec.getNegativeAckRedeliveryBackoff() != null) {
+			setNegativeAckRedeliveryBackoff(consumerSpec.getNegativeAckRedeliveryBackoff());
+		}
+		if (consumerSpec.getAckTimeoutRedeliveryBackoff() != null) {
+			setAckTimeoutRedeliveryBackoff(consumerSpec.getAckTimeoutRedeliveryBackoff());
 		}
 		if (consumerSpec.getDeadLetterPolicy() != null) {
 			setDeadLetterPolicy(consumerSpec.getDeadLetterPolicy());

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageConsumerBuilder.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageConsumerBuilder.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.KeySharedPolicy;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
@@ -524,6 +525,27 @@ public interface ReactiveMessageConsumerBuilder<T> {
 	 */
 	default ReactiveMessageConsumerBuilder<T> negativeAckRedeliveryDelay(Duration negativeAckRedeliveryDelay) {
 		getMutableSpec().setNegativeAckRedeliveryDelay(negativeAckRedeliveryDelay);
+		return this;
+	}
+
+	/**
+	 * Sets the redelivery backoff policy for messages that are negatively acknowledged.
+	 * @param negativeAckRedeliveryBackoff the backoff policy to use for negatively acknowledged messages
+	 * @return the consumer builder instance
+	 */
+	default ReactiveMessageConsumerBuilder<T> negativeAckRedeliveryBackoff(RedeliveryBackoff negativeAckRedeliveryBackoff) {
+		getMutableSpec().setNegativeAckRedeliveryBackoff(negativeAckRedeliveryBackoff);
+		return this;
+	}
+
+	/**
+	 * Sets the redelivery backoff policy for messages that are redelivered due to
+	 * acknowledgement timeout.
+	 * @param ackTimeoutRedeliveryBackoff the backoff policy to use for messages that exceed their ack timeout
+	 * @return the consumer builder instance
+	 */
+	default ReactiveMessageConsumerBuilder<T> ackTimeoutRedeliveryBackoff(RedeliveryBackoff ackTimeoutRedeliveryBackoff) {
+		getMutableSpec().setAckTimeoutRedeliveryBackoff(ackTimeoutRedeliveryBackoff);
 		return this;
 	}
 

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageConsumerSpec.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessageConsumerSpec.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.KeySharedPolicy;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
@@ -197,6 +198,22 @@ public interface ReactiveMessageConsumerSpec {
 	 * @see ConsumerBuilder#negativeAckRedeliveryDelay
 	 */
 	Duration getNegativeAckRedeliveryDelay();
+
+	/**
+	 * Get the negative ack redelivery backoff policy for messages
+	 * that are negatively acknowledged.
+	 * @return redeliveryBackoff
+	 * @see ConsumerBuilder#negativeAckRedeliveryBackoff
+	 */
+	RedeliveryBackoff getNegativeAckRedeliveryBackoff();
+
+	/**
+	 * Get the redelivery backoff policy for messages that are redelivered
+	 * due to acknowledgement timeout.
+	 * @return redeliveryBackoff
+	 * @see ConsumerBuilder#ackTimeoutRedeliveryBackoff
+	 */
+	RedeliveryBackoff getAckTimeoutRedeliveryBackoff();
 
 	/**
 	 * Gets the dead letter policy for the consumer.

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipelineBuilder.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipelineBuilder.java
@@ -38,11 +38,20 @@ public interface ReactiveMessagePipelineBuilder<T> {
 
 	/**
 	 * Sets a handler function that processes messages one-by-one.
-	 * @param messageHandler a function that takes a message as input and returns an empty
-	 * Publisher
+	 * @param messageHandler a function that takes a message as input, automatically acknowledge messages
+	 * and returns an empty Publisher.
 	 * @return a builder for the pipeline handling messages one-by-one
 	 */
 	OneByOneMessagePipelineBuilder<T> messageHandler(Function<Message<T>, Publisher<Void>> messageHandler);
+
+	/**
+	 * Sets a handler function that processes messages one-by-one.
+	 * @param messageHandler a function that takes a message as input and returns
+	 * a {@link MessageResult} that contains the acknowledgement or negative
+	 * acknowledgement value of the processing.
+	 * @return a builder for the pipeline handling messages one-by-one
+	 */
+	OneByOneMessagePipelineBuilder<T> messageHandlerWithResult(Function<Message<T>, Publisher<MessageResult<T>>> messageHandler);
 
 	/**
 	 * Sets a handler function that processes the stream of messages.

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/DefaultReactiveMessagePipelineBuilder.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/DefaultReactiveMessagePipelineBuilder.java
@@ -59,7 +59,7 @@ class DefaultReactiveMessagePipelineBuilder<T>
 
 	private final ReactiveMessageConsumer<T> messageConsumer;
 
-	private Function<Message<T>, Publisher<Void>> messageHandler;
+	private Function<Message<T>, Publisher<MessageResult<T>>> messageHandler;
 
 	private BiConsumer<Message<T>, Throwable> errorLogger;
 
@@ -86,7 +86,15 @@ class DefaultReactiveMessagePipelineBuilder<T>
 	}
 
 	@Override
-	public OneByOneMessagePipelineBuilder<T> messageHandler(Function<Message<T>, Publisher<Void>> messageHandler) {
+	public OneByOneMessagePipelineBuilder<T> messageHandler(Function<Message<T>, Publisher<Void>> messageHandlerWithoutResult) {
+		this.messageHandler = (message) ->
+			Mono.from(messageHandlerWithoutResult.apply(message))
+			.map((v) -> MessageResult.acknowledge(message));
+		return this;
+	}
+
+	@Override
+	public OneByOneMessagePipelineBuilder<T> messageHandlerWithResult(Function<Message<T>, Publisher<MessageResult<T>>> messageHandler) {
 		this.messageHandler = messageHandler;
 		return this;
 	}

--- a/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/api/MessageResultTests.java
+++ b/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/api/MessageResultTests.java
@@ -71,8 +71,8 @@ class MessageResultTests {
 	@Test
 	void acknowledgeByMessage() {
 		Message<String> message = new TestMessage();
-		MessageResult<Void> result = MessageResult.acknowledge(message);
-		assertThat(result.getValue()).isNull();
+		MessageResult<String> result = MessageResult.acknowledge(message);
+		assertThat(result.getValue()).isNotNull();
 		assertThat(result.getMessageId()).isEqualTo(MESSAGE_ID);
 		assertThat(result.isAcknowledgeMessage()).isTrue();
 	}
@@ -80,8 +80,8 @@ class MessageResultTests {
 	@Test
 	void negativeAcknowledgeByMessage() {
 		Message<String> message = new TestMessage();
-		MessageResult<Void> result = MessageResult.negativeAcknowledge(message);
-		assertThat(result.getValue()).isNull();
+		MessageResult<String> result = MessageResult.negativeAcknowledge(message);
+		assertThat(result.getValue()).isNotNull();
 		assertThat(result.getMessageId()).isEqualTo(MESSAGE_ID);
 		assertThat(result.isAcknowledgeMessage()).isFalse();
 	}

--- a/pulsar-client-reactive-jackson/src/main/java/org/apache/pulsar/reactive/client/jackson/ImmutableReactiveMessageConsumerSpecMixin.java
+++ b/pulsar-client-reactive-jackson/src/main/java/org/apache/pulsar/reactive/client/jackson/ImmutableReactiveMessageConsumerSpecMixin.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.KeySharedPolicy;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
@@ -64,6 +65,8 @@ abstract class ImmutableReactiveMessageConsumerSpecMixin {
 			@JsonProperty("acknowledgeAsynchronously") Boolean acknowledgeAsynchronously,
 			@JsonProperty("acknowledgeScheduler") Scheduler acknowledgeScheduler,
 			@JsonProperty("negativeAckRedeliveryDelay") Duration negativeAckRedeliveryDelay,
+			@JsonProperty("negativeAckRedeliveryBackoff") RedeliveryBackoff negativeAckRedeliveryBackoff,
+			@JsonProperty("ackTimeoutRedeliveryBackoff") RedeliveryBackoff ackTimeoutRedeliveryBackoff,
 			@JsonProperty("deadLetterPolicy") DeadLetterPolicy deadLetterPolicy,
 			@JsonProperty("retryLetterTopicEnable") Boolean retryLetterTopicEnable,
 			@JsonProperty("receiverQueueSize") Integer receiverQueueSize,

--- a/pulsar-client-reactive-jackson/src/main/java/org/apache/pulsar/reactive/client/jackson/PulsarReactiveClientModule.java
+++ b/pulsar-client-reactive-jackson/src/main/java/org/apache/pulsar/reactive/client/jackson/PulsarReactiveClientModule.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.KeySharedPolicy;
 import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.Range;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.reactive.client.api.ImmutableReactiveMessageConsumerSpec;
 import org.apache.pulsar.reactive.client.api.ImmutableReactiveMessageReaderSpec;
 import org.apache.pulsar.reactive.client.api.ImmutableReactiveMessageSenderSpec;
@@ -63,6 +64,8 @@ public class PulsarReactiveClientModule extends SimpleModule {
 		addDeserializer(Scheduler.class, new SchedulerDeserializer());
 		addSerializer(Scheduler.class, new SchedulerSerializer());
 		addDeserializer(DeadLetterPolicy.class, new DeadLetterPolicyDeserializer());
+		addDeserializer(RedeliveryBackoff.class, new ClassDeserializer<>());
+		addSerializer(RedeliveryBackoff.class, new ClassSerializer<>());
 		addDeserializer(CryptoKeyReader.class, new ClassDeserializer<>());
 		addSerializer(CryptoKeyReader.class, new ClassSerializer<>());
 		addDeserializer(Range.class, new RangeDeserializer());


### PR DESCRIPTION
Here is a proposal to provide a ReactiveMessagePipeline implementation allowing to negatively ack messages and provide a [RedliveryBackoff](https://pulsar.apache.org/api/client/4.0.x/org/apache/pulsar/client/api/RedeliveryBackoff.html) to the ReactiveMessageSender. Thus, you can really benefit from Pulsar redelivery support.