### PR TITLE
Fix negative acknowledgement handling for ReactiveMessagePipeline when message handler throws an exception

### DIFF
--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipelineBuilder.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipelineBuilder.java
@@ -37,11 +37,23 @@ import reactor.util.retry.Retry;
 public interface ReactiveMessagePipelineBuilder<T> {
 
 	/**
+	 * <p>
 	 * Sets a handler function that processes messages one-by-one. When the message
 	 * handler completes successfully, the message will be acknowledged. When the message
 	 * handler emits an error, the error logger will be used to log the error and the
 	 * message will be negatively acknowledged. If the error logger is not set, a default
 	 * error message will be logged at the error level.
+	 * </p>
+	 * <p>
+	 * NOTE: Be aware that negative acknowledgements on ordered subscription types such as
+	 * Exclusive, Failover and Key_Shared typically cause failed messages to be sent to
+	 * consumers out of their original order. Negative acknowledgements for Key_Shared
+	 * subscriptions may also cause message delivery to be blocked on broker versions
+	 * before Pulsar 4.0. To maintain ordered message processing, it is recommended to
+	 * wrap the message handler with Project Reactor's native retry logic using <a href=
+	 * "https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#retryWhen-reactor.util.retry.Retry-">Mono.retryWhen</a>
+	 * to retry processing of each message indefinitely with backoff.
+	 * </p>
 	 * @param messageHandler a function that takes a message as input and returns an empty
 	 * Publisher
 	 * @return a builder for the pipeline handling messages one-by-one

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipelineBuilder.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipelineBuilder.java
@@ -37,7 +37,11 @@ import reactor.util.retry.Retry;
 public interface ReactiveMessagePipelineBuilder<T> {
 
 	/**
-	 * Sets a handler function that processes messages one-by-one.
+	 * Sets a handler function that processes messages one-by-one. When the message
+	 * handler completes successfully, the message will be acknowledged. When the message
+	 * handler emits an error, the error logger will be used to log the error and the
+	 * message will be negatively acknowledged. If the error logger is not set, a default
+	 * error message will be logged at the error level.
 	 * @param messageHandler a function that takes a message as input and returns an empty
 	 * Publisher
 	 * @return a builder for the pipeline handling messages one-by-one
@@ -95,6 +99,7 @@ public interface ReactiveMessagePipelineBuilder<T> {
 
 		/**
 		 * Sets a function which will be called when the message handler emits an error.
+		 * If not set, a default message will be logged at the error level.
 		 * @param errorLogger the error logger function
 		 * @return the pipeline builder instance
 		 */

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/DefaultReactiveMessagePipeline.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/DefaultReactiveMessagePipeline.java
@@ -143,7 +143,7 @@ class DefaultReactiveMessagePipeline<T> implements ReactiveMessagePipeline {
 	}
 
 	private Mono<MessageResult<Void>> handleMessage(Message<T> message) {
-		return Mono.from(this.messageHandler.apply(message))
+		return Mono.defer(() -> Mono.from(this.messageHandler.apply(message)))
 			.transform(this::decorateMessageHandler)
 			.thenReturn(MessageResult.acknowledge(message.getMessageId()))
 			.onErrorResume((throwable) -> {


### PR DESCRIPTION
Fixes #210

There was a bug in negative acknowledgement handling when the message handler function throws an exception. 
An exception would cause the whole pipeline to be restarted, which is not intended. 
The problem was that the message handler function wasn't wrapped with `Mono.defer` which captures possible exceptions.

This PR adds a test case, javadoc and fixes the issue.

