### PR TITLE
Add untilStarted & untilStopped to ReactiveMessagePipeline

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ log4j-slf4j2-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", ver
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 pulsar-client-api = { module = "org.apache.pulsar:pulsar-client-api", version.ref = "pulsar" }
 pulsar-client-shaded = { module = "org.apache.pulsar:pulsar-client", version.ref = "pulsar" }
+pulsar-client-all = { module = "org.apache.pulsar:pulsar-client-all", version.ref = "pulsar" }
 rat-gradle = { module = "org.nosphere.apache:creadur-rat-gradle", version.ref = "rat-gradle" }
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactor" }
 reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "reactor" }

--- a/pulsar-client-reactive-adapter/build.gradle
+++ b/pulsar-client-reactive-adapter/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	testImplementation libs.bundles.log4j
 	testImplementation libs.mockito.core
 
+	intTestImplementation libs.pulsar.client.all
 	intTestImplementation project(':pulsar-client-reactive-producer-cache-caffeine')
 	intTestImplementation project(path: ':pulsar-client-reactive-producer-cache-caffeine-shaded', configuration: 'shadow')
 	intTestImplementation libs.junit.jupiter

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessagePipelineE2ETests.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessagePipelineE2ETests.java
@@ -36,8 +36,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.policies.data.SubscriptionStats;
+import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.reactive.client.api.MessageSpec;
 import org.apache.pulsar.reactive.client.api.MessageSpecBuilder;
 import org.apache.pulsar.reactive.client.api.ReactiveMessagePipeline;
@@ -91,6 +94,38 @@ class ReactiveMessagePipelineE2ETests {
 				assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
 				assertThat(messages).isEqualTo(Flux.range(1, 100).map(Object::toString).collectList().block());
 			}
+		}
+	}
+
+	@Test
+	void shouldSupportWaitingForConsumingToStartAndStop() throws Exception {
+		try (PulsarClient pulsarClient = SingletonPulsarContainer.createPulsarClient();
+				PulsarAdmin pulsarAdmin = SingletonPulsarContainer.createPulsarAdmin()) {
+			String topicName = "test" + UUID.randomUUID();
+			ReactivePulsarClient reactivePulsarClient = AdaptedReactivePulsarClientFactory.create(pulsarClient);
+			ReactiveMessagePipeline pipeline = reactivePulsarClient.messageConsumer(Schema.STRING)
+				.subscriptionName("sub")
+				.topic(topicName)
+				.build()
+				.messagePipeline()
+				.messageHandler((message) -> Mono.empty())
+				.build()
+				.start();
+
+			// wait for consuming to start
+			pipeline.untilConsumingStarted().block(Duration.ofSeconds(5));
+			// there should be an existing subscription
+			List<String> subscriptions = pulsarAdmin.topics().getSubscriptions(topicName);
+			assertThat(subscriptions).as("subscription should be created").contains("sub");
+
+			// stop the pipeline
+			pipeline.stop();
+			// and wait for it to stop
+			pipeline.untilConsumingStopped().block(Duration.ofSeconds(5));
+			// there should be no consumers
+			TopicStats topicStats = pulsarAdmin.topics().getStats(topicName);
+			SubscriptionStats subStats = topicStats.getSubscriptions().get("sub");
+			assertThat(subStats.getConsumers()).isEmpty();
 		}
 	}
 

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessagePipelineE2ETests.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/ReactiveMessagePipelineE2ETests.java
@@ -113,7 +113,7 @@ class ReactiveMessagePipelineE2ETests {
 				.start();
 
 			// wait for consuming to start
-			pipeline.untilConsumingStarted().block(Duration.ofSeconds(5));
+			pipeline.untilStarted().block(Duration.ofSeconds(5));
 			// there should be an existing subscription
 			List<String> subscriptions = pulsarAdmin.topics().getSubscriptions(topicName);
 			assertThat(subscriptions).as("subscription should be created").contains("sub");
@@ -121,7 +121,7 @@ class ReactiveMessagePipelineE2ETests {
 			// stop the pipeline
 			pipeline.stop();
 			// and wait for it to stop
-			pipeline.untilConsumingStopped().block(Duration.ofSeconds(5));
+			pipeline.untilStopped().block(Duration.ofSeconds(5));
 			// there should be no consumers
 			TopicStats topicStats = pulsarAdmin.topics().getStats(topicName);
 			SubscriptionStats subStats = topicStats.getSubscriptions().get("sub");

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/SingletonPulsarContainer.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/SingletonPulsarContainer.java
@@ -19,6 +19,7 @@
 
 package org.apache.pulsar.reactive.client.adapter;
 
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.testcontainers.containers.PulsarContainer;
@@ -41,6 +42,12 @@ final class SingletonPulsarContainer {
 	static PulsarClient createPulsarClient() throws PulsarClientException {
 		return PulsarClient.builder()
 			.serviceUrl(SingletonPulsarContainer.PULSAR_CONTAINER.getPulsarBrokerUrl())
+			.build();
+	}
+
+	static PulsarAdmin createPulsarAdmin() throws PulsarClientException {
+		return PulsarAdmin.builder()
+			.serviceHttpUrl(SingletonPulsarContainer.PULSAR_CONTAINER.getHttpServiceUrl())
 			.build();
 	}
 

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
@@ -29,16 +29,16 @@ public interface ReactiveMessagePipeline extends AutoCloseable {
 	/**
 	 * Starts the reactive pipeline asynchronously.
 	 * @return the pipeline instance
-	 * @see #untilConsumingStarted() For returning a reactive publisher (Mono) that
-	 * completes after consuming has actually started.
+	 * @see #untilStarted() For returning a reactive publisher (Mono) that completes after
+	 * the pipeline has actually started.
 	 */
 	ReactiveMessagePipeline start();
 
 	/**
 	 * Stops the reactive pipeline asynchronously.
 	 * @return the pipeline instance
-	 * @see #untilConsumingStopped() For returning a reactive publisher (Mono) that
-	 * completes after consuming has actually stopped.
+	 * @see #untilStopped() For returning a reactive publisher (Mono) that completes after
+	 * the pipeline has actually stopped.
 	 */
 	ReactiveMessagePipeline stop();
 
@@ -76,7 +76,7 @@ public interface ReactiveMessagePipeline extends AutoCloseable {
 	 * @return a Mono that completes after the pipeline has created its underlying Pulsar
 	 * consumer
 	 */
-	default Mono<Void> untilConsumingStarted() {
+	default Mono<Void> untilStarted() {
 		return Mono.empty();
 	}
 
@@ -95,7 +95,7 @@ public interface ReactiveMessagePipeline extends AutoCloseable {
 	 * @return a Mono that completes when the pipeline has closed the underlying Pulsar
 	 * consumer
 	 */
-	default Mono<Void> untilConsumingStopped() {
+	default Mono<Void> untilStopped() {
 		return Mono.empty();
 	}
 

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
@@ -27,17 +27,18 @@ import reactor.core.publisher.Mono;
 public interface ReactiveMessagePipeline extends AutoCloseable {
 
 	/**
-	 * Starts the reactive pipeline asynchronously. Call the
-	 * {@link #untilConsumingStarted()} method after calling {@link #start()} to wait for
-	 * the pipeline to start consuming messages.
+	 * Starts the reactive pipeline asynchronously.
+	 *
+	 * @see #untilConsumingStarted() For returning a reactive publisher (Mono) that
+	 * completes after consuming has actually started.
 	 * @return the pipeline
 	 */
 	ReactiveMessagePipeline start();
 
 	/**
-	 * Stops the reactive pipeline asynchronously. To wait for the pipeline to stop
-	 * consuming messages, call the {@link #untilConsumingStopped()} method after
-	 * {@link #stop()}.
+	 * Stops the reactive pipeline asynchronously.
+	 * @see #untilConsumingStopped() For returning a reactive publisher (Mono) that
+	 * completes after consuming has actually stopped.
 	 * @return the reactive pipeline
 	 */
 	ReactiveMessagePipeline stop();

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
@@ -19,6 +19,8 @@
 
 package org.apache.pulsar.reactive.client.api;
 
+import reactor.core.publisher.Mono;
+
 /**
  * Reactive message pipeline interface.
  */
@@ -48,6 +50,24 @@ public interface ReactiveMessagePipeline extends AutoCloseable {
 	 */
 	default void close() throws Exception {
 		stop();
+	}
+
+	/**
+	 * Waits for consuming to be started. It is required to call {#@link #start()} before
+	 * calling this method.
+	 * @return a Mono that is completed after the pipeline is consuming messages.
+	 */
+	default Mono<Void> untilConsumingStarted() {
+		return Mono.empty();
+	}
+
+	/**
+	 * Waits until consuming has stopped when stopping the pipeline. It is required to
+	 * call {#@link #stop()} before calling this method.
+	 * @return a Mono that is completed when the pipeline has stopped consuming messages.
+	 */
+	default Mono<Void> untilConsumingStopped() {
+		return Mono.empty();
 	}
 
 }

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
@@ -27,17 +27,17 @@ import reactor.core.publisher.Mono;
 public interface ReactiveMessagePipeline extends AutoCloseable {
 
 	/**
-	 * Starts the reactive pipeline asynchronously. Use the
-	 * {@link #untilConsumingStarted()} method for waiting for the pipeline to start
-	 * consuming messages.
+	 * Starts the reactive pipeline asynchronously. Call the
+	 * {@link #untilConsumingStarted()} method after calling {@link #start()} to wait for
+	 * the pipeline to start consuming messages.
 	 * @return the pipeline
 	 */
 	ReactiveMessagePipeline start();
 
 	/**
-	 * Stops the reactive pipeline asynchronously. Use the
-	 * {@link #untilConsumingStopped()} method for waiting for the pipeline to stop
-	 * consuming messages.
+	 * Stops the reactive pipeline asynchronously. To wait for the pipeline to stop
+	 * consuming messages, call the {@link #untilConsumingStopped()} method after
+	 * {@link #stop()}.
 	 * @return the reactive pipeline
 	 */
 	ReactiveMessagePipeline stop();
@@ -49,7 +49,8 @@ public interface ReactiveMessagePipeline extends AutoCloseable {
 	boolean isRunning();
 
 	/**
-	 * Closes the reactive pipeline.
+	 * Closes the reactive pipeline asynchronously without waiting for shutdown
+	 * completion.
 	 * @throws Exception if an error occurs
 	 */
 	default void close() throws Exception {

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
@@ -27,13 +27,17 @@ import reactor.core.publisher.Mono;
 public interface ReactiveMessagePipeline extends AutoCloseable {
 
 	/**
-	 * Starts the reactive pipeline.
+	 * Starts the reactive pipeline asynchronously. Use the
+	 * {@link #untilConsumingStarted()} method for waiting for the pipeline to start
+	 * consuming messages.
 	 * @return the pipeline
 	 */
 	ReactiveMessagePipeline start();
 
 	/**
-	 * Stops the reactive pipeline.
+	 * Stops the reactive pipeline asynchronously. Use the
+	 * {@link #untilConsumingStopped()} method for waiting for the pipeline to stop
+	 * consuming messages.
 	 * @return the reactive pipeline
 	 */
 	ReactiveMessagePipeline stop();

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
@@ -28,18 +28,17 @@ public interface ReactiveMessagePipeline extends AutoCloseable {
 
 	/**
 	 * Starts the reactive pipeline asynchronously.
-	 *
+	 * @return the pipeline instance
 	 * @see #untilConsumingStarted() For returning a reactive publisher (Mono) that
 	 * completes after consuming has actually started.
-	 * @return the pipeline
 	 */
 	ReactiveMessagePipeline start();
 
 	/**
 	 * Stops the reactive pipeline asynchronously.
+	 * @return the pipeline instance
 	 * @see #untilConsumingStopped() For returning a reactive publisher (Mono) that
 	 * completes after consuming has actually stopped.
-	 * @return the reactive pipeline
 	 */
 	ReactiveMessagePipeline stop();
 

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipeline.java
@@ -58,18 +58,42 @@ public interface ReactiveMessagePipeline extends AutoCloseable {
 	}
 
 	/**
-	 * Waits for consuming to be started. It is required to call {#@link #start()} before
-	 * calling this method.
-	 * @return a Mono that is completed after the pipeline is consuming messages.
+	 * <p>
+	 * Returns a reactive publisher (Mono) that completes after the pipeline has
+	 * successfully subscribed to the input topic(s) and started consuming messages for
+	 * the first time after pipeline creation. This method is not intended to be used
+	 * after a pipeline restarts following failure. Use this method to wait for consumer
+	 * and Pulsar subscription creation. This helps avoid race conditions when sending
+	 * messages immediately after the pipeline starts.
+	 * </p>
+	 * <p>
+	 * The {@link #start()} method must be called before invoking this method.
+	 * </p>
+	 * <p>
+	 * To wait for the operation to complete synchronously, it is necessary to call
+	 * {@link Mono#block()} on the returned Mono.
+	 * </p>
+	 * @return a Mono that completes after the pipeline has created its underlying Pulsar
+	 * consumer
 	 */
 	default Mono<Void> untilConsumingStarted() {
 		return Mono.empty();
 	}
 
 	/**
-	 * Waits until consuming has stopped when stopping the pipeline. It is required to
-	 * call {#@link #stop()} before calling this method.
-	 * @return a Mono that is completed when the pipeline has stopped consuming messages.
+	 * <p>
+	 * Returns a reactive publisher (Mono) that completes after the pipeline has closed
+	 * the underlying Pulsar consumer and stopped consuming new messages.
+	 * </p>
+	 * <p>
+	 * The {@link #stop()} method must be called before invoking this method.
+	 * </p>
+	 * <p>
+	 * To wait for the operation to complete synchronously, it is necessary to call
+	 * {@link Mono#block()} on the returned Mono.
+	 * </p>
+	 * @return a Mono that completes when the pipeline has closed the underlying Pulsar
+	 * consumer
 	 */
 	default Mono<Void> untilConsumingStopped() {
 		return Mono.empty();

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/DefaultReactiveMessagePipeline.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/DefaultReactiveMessagePipeline.java
@@ -187,9 +187,7 @@ class DefaultReactiveMessagePipeline<T> implements ReactiveMessagePipeline {
 			disposable.dispose();
 			throw new IllegalStateException("Message handler was already running.");
 		}
-		else {
-			this.consumerListener.set(consumerListener);
-		}
+		this.consumerListener.set(consumerListener);
 		return this;
 	}
 

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/DefaultReactiveMessagePipeline.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/DefaultReactiveMessagePipeline.java
@@ -90,12 +90,12 @@ class DefaultReactiveMessagePipeline<T> implements ReactiveMessagePipeline {
 			.transform(transformer)
 			.transform(this::decoratePipeline)
 			.doFinally((signalType) -> {
-				CompletableFuture<Void> f = pipelineStoppedFuture.get();
+				CompletableFuture<Void> f = this.pipelineStoppedFuture.get();
 				if (f != null) {
 					f.complete(null);
 				}
 			})
-			.doFirst(() -> pipelineStoppedFuture.set(new CompletableFuture<>()));
+			.doFirst(() -> this.pipelineStoppedFuture.set(new CompletableFuture<>()));
 	}
 
 	private Mono<Void> decorateMessageHandler(Mono<Void> messageHandler) {
@@ -194,7 +194,7 @@ class DefaultReactiveMessagePipeline<T> implements ReactiveMessagePipeline {
 	}
 
 	@Override
-	public Mono<Void> untilConsumingStarted() {
+	public Mono<Void> untilStarted() {
 		if (!isRunning()) {
 			throw new IllegalStateException("Pipeline isn't running. Call start first.");
 		}
@@ -222,11 +222,11 @@ class DefaultReactiveMessagePipeline<T> implements ReactiveMessagePipeline {
 	}
 
 	@Override
-	public Mono<Void> untilConsumingStopped() {
+	public Mono<Void> untilStopped() {
 		if (isRunning()) {
 			throw new IllegalStateException("Pipeline is running. Call stop first.");
 		}
-		CompletableFuture<Void> f = pipelineStoppedFuture.get();
+		CompletableFuture<Void> f = this.pipelineStoppedFuture.get();
 		if (f != null) {
 			return Mono.fromFuture(f, true);
 		}

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/InternalConsumerListener.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/InternalConsumerListener.java
@@ -30,13 +30,17 @@ public interface InternalConsumerListener {
 	 * consumer is created initially or as a result of a reactive pipeline retry.
 	 * @param nativeConsumer the native consumer instance
 	 */
-	void onConsumerCreated(Object nativeConsumer);
+	default void onConsumerCreated(Object nativeConsumer) {
+		// no-op
+	}
 
 	/**
 	 * Called when a native consumer is closed. This is called each time a consumer is
 	 * closed as a result of a reactive pipeline retry or when the pipeline is closed.
 	 * @param nativeConsumer the native consumer instance
 	 */
-	void onConsumerClosed(Object nativeConsumer);
+	default void onConsumerClosed(Object nativeConsumer) {
+		// no-op
+	}
 
 }

--- a/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/InternalConsumerListener.java
+++ b/pulsar-client-reactive-api/src/main/java/org/apache/pulsar/reactive/client/internal/api/InternalConsumerListener.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.reactive.client.internal.api;
+
+/**
+ * Internal interface to signal the creation and closing of a native consumer. This is not
+ * to be intended to be used by applications.
+ */
+public interface InternalConsumerListener {
+
+	/**
+	 * Called when a new native consumer is created. This is called each time a new
+	 * consumer is created initially or as a result of a reactive pipeline retry.
+	 * @param nativeConsumer the native consumer instance
+	 */
+	void onConsumerCreated(Object nativeConsumer);
+
+	/**
+	 * Called when a native consumer is closed. This is called each time a consumer is
+	 * closed as a result of a reactive pipeline retry or when the pipeline is closed.
+	 * @param nativeConsumer the native consumer instance
+	 */
+	void onConsumerClosed(Object nativeConsumer);
+
+}

--- a/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipelineTests.java
+++ b/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipelineTests.java
@@ -168,7 +168,7 @@ class ReactiveMessagePipelineTests {
 	}
 
 	@Test
-	void pipelineUntilConsumingStartedAndStopped() throws Exception {
+	void pipelineUntilStartedAndStopped() throws Exception {
 		int numMessages = 10;
 		Duration subscriptionDelay = Duration.ofSeconds(1);
 		TestConsumer testConsumer = new TestConsumer(numMessages, subscriptionDelay);
@@ -178,14 +178,14 @@ class ReactiveMessagePipelineTests {
 		ReactiveMessagePipeline pipeline = testConsumer.messagePipeline().messageHandler(messageHandler).build();
 		pipeline.start();
 		// timeout should occur since subscription delay is 1 second in TestConsumer
-		assertThatThrownBy(() -> pipeline.untilConsumingStarted().block(Duration.ofMillis(100)))
+		assertThatThrownBy(() -> pipeline.untilStarted().block(Duration.ofMillis(100)))
 			.isInstanceOf(IllegalStateException.class)
 			.hasCauseInstanceOf(TimeoutException.class);
 		// now wait for consuming to start
-		pipeline.untilConsumingStarted().block(Duration.ofSeconds(2));
+		pipeline.untilStarted().block(Duration.ofSeconds(2));
 		assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
 		// now wait for consuming to stop
-		pipeline.stop().untilConsumingStopped().block(Duration.ofSeconds(1));
+		pipeline.stop().untilStopped().block(Duration.ofSeconds(1));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #212

This adds `untilStarted` and `untilStopped` methods to `ReactiveMessagePipeline`.
`untilStarted` will get completed after calling `start` when the actual Pulsar consumer has been created. 
`untilStopped` will get completed after calling `stop` when the pipeline has been completely closed.