### PR TITLE
Temp allow merging own PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -51,7 +51,7 @@ github:
 
       required_pull_request_reviews:
         dismiss_stale_reviews: false
-        require_code_owner_reviews: true
+        require_code_owner_reviews: false
         required_approving_review_count: 1
 
       # squash or rebase must be allowed in the repo for this setting to be set to true.


### PR DESCRIPTION
This temporarily allows code owners to merge their own PRs as this is needed while the team is out on PTO and we have a release about to take place.