### PR TITLE
Update version from `0.6.1-SNAPSHOT` to `0.7.0-SNAPSHOT`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-version=0.6.1-SNAPSHOT
+version=0.7.0-SNAPSHOT


### PR DESCRIPTION
Accounts for the fact that the mainline has new features (redelivery backoff policy settings) and deprecations.