### PR TITLE
Update Pulsar to 4.1.1 and Reactor to 3.8.0-RC1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,19 +22,20 @@ assertj = "3.26.3"
 caffeine = "2.9.3"
 checkstyle = "9.3"
 # @pin
-jackson = "2.14.2"
+jackson = "2.20.0"
+
 # @pin
 jctools = "3.3.0"
 junit-jupiter = "5.11.3"
 licenser = "0.6.1"
-log4j = "2.24.3"
-mockito = "5.18.0"
-pulsar = "4.0.5"
+log4j = "2.25.2"
+mockito = "5.20.0"
+pulsar = "4.1.1"
 rat-gradle = "0.8.0"
-reactor = "3.6.17"
+reactor = "3.8.0-RC1"
 slf4j = "2.0.17"
-spring-javaformat = "0.0.46"
-testcontainers = "1.21.1"
+spring-javaformat = "0.0.47"
+testcontainers = "1.21.3"
 testlogger = "3.2.0"
 
 [libraries]

--- a/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/SingletonPulsarContainer.java
+++ b/pulsar-client-reactive-adapter/src/intTest/java/org/apache/pulsar/reactive/client/adapter/SingletonPulsarContainer.java
@@ -52,7 +52,7 @@ final class SingletonPulsarContainer {
 	}
 
 	static DockerImageName getPulsarImage() {
-		return DockerImageName.parse("apachepulsar/pulsar:4.0.4");
+		return DockerImageName.parse("apachepulsar/pulsar:4.1.1");
 	}
 
 }

--- a/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/api/MessageResultTests.java
+++ b/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/api/MessageResultTests.java
@@ -217,6 +217,11 @@ class MessageResultTests {
 		}
 
 		@Override
+		public Optional<byte[]> getSchemaId() {
+			return Optional.empty();
+		}
+
+		@Override
 		public boolean isReplicated() {
 			return false;
 		}

--- a/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipelineTests.java
+++ b/pulsar-client-reactive-api/src/test/java/org/apache/pulsar/reactive/client/api/ReactiveMessagePipelineTests.java
@@ -686,6 +686,11 @@ class ReactiveMessagePipelineTests {
 		}
 
 		@Override
+		public Optional<byte[]> getSchemaId() {
+			return Optional.empty();
+		}
+
+		@Override
 		public boolean isReplicated() {
 			return false;
 		}

--- a/scripts/validate_staging_repo.sh
+++ b/scripts/validate_staging_repo.sh
@@ -40,7 +40,7 @@ if ! command -v gradle &>/dev/null; then
 fi
 
 DOCKER_CONTAINER_NAME=pulsar-standalone-$$
-: ${DOCKER_IMAGE_NAME:=apachepulsar/pulsar:4.0.4}
+: ${DOCKER_IMAGE_NAME:=apachepulsar/pulsar:4.1.1}
 
 mkdir test-app-reactive-$$
 cd test-app-reactive-$$
@@ -90,7 +90,7 @@ public class HelloPulsarClientReactive {
 
     public static void main(String[] args) throws PulsarClientException, InterruptedException {
         // Before running this, start Pulsar within docker with this command:
-        // docker run -it -p 8080:8080 -p 6650:6650 apachepulsar/pulsar:4.0.4 /pulsar/bin/pulsar standalone -nss -nfw
+        // docker run -it -p 8080:8080 -p 6650:6650 apachepulsar/pulsar:4.1.1 /pulsar/bin/pulsar standalone -nss -nfw
 
         try (PulsarClient pulsarClient = PulsarClient.builder().serviceUrl("pulsar://localhost:6650").build()) {
 


### PR DESCRIPTION
This commit updates the following dependency versions in preparation for the upcoming `1.0.0` release.

- Pulsar from `4.0.5` to `4.1.1`
- Jackson from `2.14.2` to `2.20.0`
- Log4j from `2.24.3` to `2.25.2`
- Reactor from `3.6.17` to `3.8.0-RC1`