### PR TITLE
[fix][ci] Use approved hash for gradle/actions/setup-gradle action, upgrade official actions and fix tune-runner-vm

### DIFF
--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -7,7 +7,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -7,7 +7,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   https://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -22,7 +22,8 @@ description: tunes the GitHub Runner VM operation system
 runs:
   using: composite
   steps:
-    - run: |
+    - shell: bash
+      run: |
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
             echo "::group::Configure and tune OS"
             # Ensure that reverse lookups for current hostname are handled properly
@@ -33,50 +34,41 @@ runs:
             # consumption is high.
             # Set vm.swappiness=1 to avoid swapping and allow high RAM usage
             echo 1 | sudo tee /proc/sys/vm/swappiness
-            (
-              shopt -s nullglob
-              # Set swappiness to 1 for all cgroups and sub-groups
-              for swappiness_file in /sys/fs/cgroup/memory/*/memory.swappiness /sys/fs/cgroup/memory/*/*/memory.swappiness; do
-                echo 1 | sudo tee $swappiness_file > /dev/null
-              done
-            ) || true
 
             # use "madvise" Linux Transparent HugePages (THP) setting
             # https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html
             # "madvise" is generally a better option than the default "always" setting
-            # Based on Azul instructions from https://docs.azul.com/prime/Enable-Huge-Pages#transparent-huge-pages-thp
+            # recommendation from https://netflixtechblog.com/bending-pause-times-to-your-will-with-generational-zgc-256629c9386b
             echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
             echo advise | sudo tee /sys/kernel/mm/transparent_hugepage/shmem_enabled
-            echo defer+madvise | sudo tee /sys/kernel/mm/transparent_hugepage/defrag
+            echo defer | sudo tee /sys/kernel/mm/transparent_hugepage/defrag
             echo 1 | sudo tee /sys/kernel/mm/transparent_hugepage/khugepaged/defrag
     
             # tune filesystem mount options, https://www.kernel.org/doc/Documentation/filesystems/ext4.txt
             # commit=999999, effectively disables automatic syncing to disk (default is every 5 seconds)
             # nobarrier/barrier=0, loosen data consistency on system crash (no negative impact to empheral CI nodes)
             sudo mount -o remount,nodiscard,commit=999999,barrier=0 / || true
-            sudo mount -o remount,nodiscard,commit=999999,barrier=0 /mnt || true
+            if mountpoint -q /mnt; then
+              sudo mount -o remount,nodiscard,commit=999999,barrier=0 /mnt || true
+            fi
             # disable discard/trim at device level since remount with nodiscard doesn't seem to be effective
             # https://www.spinics.net/lists/linux-ide/msg52562.html
-            for i in /sys/block/sd*/queue/discard_max_bytes; do
-              echo 0 | sudo tee $i
+            for i in /sys/block/*/queue/discard_max_bytes; do
+              if [ -f "$i" ]; then
+                echo 0 | sudo tee "$i"
+              fi
             done
-            # disable any background jobs that run SSD discard/trim
-            sudo systemctl disable fstrim.timer || true
-            sudo systemctl stop fstrim.timer || true
-            sudo systemctl disable fstrim.service || true
-            sudo systemctl stop fstrim.service || true
+            # disable unnecessary timers
+            sudo systemctl stop fstrim.timer fstrim.service \
+              podman-auto-update.timer sysstat-collect.timer sysstat-summary.timer \
+              phpsessionclean.timer man-db.timer motd-news.timer \
+              dpkg-db-backup.timer e2scrub_all.timer \
+              update-notifier-download.timer update-notifier-motd.timer || true
 
-            # stop php-fpm
-            sudo systemctl stop php8.0-fpm.service || true
-            sudo systemctl stop php7.4-fpm.service || true
-            # stop mono-xsp4
-            sudo systemctl disable mono-xsp4.service || true
-            sudo systemctl stop mono-xsp4.service || true
-            sudo killall mono || true
+            # stop unnecessary services
+            sudo systemctl stop php8.3-fpm.service ModemManager.service \
+              multipathd.socket multipathd.service udisks2.service walinuxagent.service || true
 
-            # stop Azure Linux agent to save RAM
-            sudo systemctl stop walinuxagent.service || true
-          
             echo '::endgroup::'
 
             # show memory
@@ -87,10 +79,4 @@ runs:
             echo "::group::Available diskspace"
             df -BM
             echo "::endgroup::"
-            # show cggroup
-            echo "::group::Cgroup settings for current cgroup $CURRENT_CGGROUP"
-            CURRENT_CGGROUP=$(cat /proc/self/cgroup | grep '0::' | awk -F: '{ print $3 }')
-            sudo cgget -a $CURRENT_CGGROUP || true
-            echo '::endgroup::'
         fi
-      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
+          distribution: corretto
           java-version: 17
 
       - name: Setup Gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Check with Gradle
         run: ./gradlew rat licenseCheck javadoc check


### PR DESCRIPTION
Use approved hash for gradle/actions/setup-gradle action
- allowed hashes are at https://github.com/apache/infrastructure-actions/blob/main/actions.yml (compiled list at https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml)
- fix outdated tune-runner-vm
- upgrade official actions