### PR TITLE
Fix JUnit platform launcher/engine version skew after JUnit 6 upgrade

### DIFF
--- a/buildSrc/src/main/groovy/pulsar-client-reactive.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/pulsar-client-reactive.library-conventions.gradle
@@ -38,6 +38,10 @@ compileJava {
 	options.release = 8
 }
 
+dependencies {
+	testRuntimeOnly libs.junit.platform.launcher
+}
+
 tasks.withType(Test) {
 	useJUnitPlatform()
 }

--- a/buildSrc/src/main/groovy/pulsar-client-reactive.test-conventions.gradle
+++ b/buildSrc/src/main/groovy/pulsar-client-reactive.test-conventions.gradle
@@ -42,6 +42,7 @@ dependencies {
 	def sharedTestResourcesEntry = files(new File(rootDir, "shared-test-resources"))
 	intTestRuntimeOnly sharedTestResourcesEntry
 	testRuntimeOnly sharedTestResourcesEntry
+	intTestRuntimeOnly libs.junit.platform.launcher
 }
 
 tasks.register('integrationTest', Test) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ checkstyle = "9.3"
 jackson = "2.18.5"
 # @pin
 jctools = "3.3.0"
-junit-jupiter = "5.11.4"
+junit-jupiter = "6.1.3"
 licenser = "0.6.1"
 log4j = "2.24.3"
 mockito = "5.18.0"
@@ -45,6 +45,7 @@ jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-dat
 jctools-core = { module = "org.jctools:jctools-core", version.ref = "jctools" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-jupiter" }
 licenser = { module = "gradle.plugin.org.cadixdev.gradle:licenser", version.ref = "licenser" }
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }


### PR DESCRIPTION
junit-jupiter was bumped to 6.1.3, but junit-platform-launcher was left to Gradle's built-in default, which only knows about the old JUnit platform 1.x line. This caused test discovery to fail with "OutputDirectoryCreator not available" since junit-platform-engine 6.x and the injected launcher were unaligned. Explicitly declare junit-platform-launcher at the same version and wire it into both the test and intTest runtime classpaths.